### PR TITLE
Misc: Add Eclipse & Intellij project files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,16 @@ UpgradeLog*.htm
 App_Data/*.mdf
 App_Data/*.ldf
 
+# Eclipse
+.classpath
+.project
+.settings/
+
+# Intellij
+.idea/
+*.iml
+*.iws
+
 # =========================
 # Windows detritus
 # =========================


### PR DESCRIPTION
This expands the .gitignore file to ignore Intellij and Eclipse Project files.