### PR TITLE
Port code over to use with botan-1.11

### DIFF
--- a/src/account/Service.cpp
+++ b/src/account/Service.cpp
@@ -140,7 +140,7 @@ void Service::send_locate_reply(const spark::Link& link, const em::MessageRoot* 
 
 	if(key) {
 		auto encoded_key = Botan::BigInt::encode(*key);
-		klb.add_key(fbb->CreateVector(encoded_key.begin(), encoded_key.size()));
+		klb.add_key(fbb->CreateVector(encoded_key.data(), encoded_key.size()));
 		status = em::account::Status::OK;
 	} else {
 		status = em::account::Status::SESSION_NOT_FOUND;

--- a/src/gateway/ClientConnection.cpp
+++ b/src/gateway/ClientConnection.cpp
@@ -172,7 +172,7 @@ void ClientConnection::swap_buffers() {
 }
 
 void ClientConnection::set_authenticated(const Botan::BigInt& key) {
-	auto k_bytes = Botan::BigInt::encode_locked(key);
+	auto k_bytes = Botan::BigInt::encode(key);
 	crypto_.set_key(k_bytes);
 	authenticated_ = true;
 }

--- a/src/gateway/ClientConnection.cpp
+++ b/src/gateway/ClientConnection.cpp
@@ -172,7 +172,7 @@ void ClientConnection::swap_buffers() {
 }
 
 void ClientConnection::set_authenticated(const Botan::BigInt& key) {
-	auto k_bytes = Botan::BigInt::encode(key);
+	auto k_bytes = Botan::BigInt::encode_locked(key);
 	crypto_.set_key(k_bytes);
 	authenticated_ = true;
 }

--- a/src/gateway/Events.h
+++ b/src/gateway/Events.h
@@ -18,6 +18,7 @@
 #include <utility>
 #include <cstdint>
 #include <cstddef>
+#include <botan/bigint.h>
 
 namespace ember {
 

--- a/src/gateway/Events.h
+++ b/src/gateway/Events.h
@@ -14,11 +14,11 @@
 #include <shared/database/objects/Character.h>
 #include <spark/temp/Account_generated.h>
 #include <spark/temp/Character_generated.h>
+#include <botan/bigint.h>
 #include <vector>
 #include <utility>
 #include <cstdint>
 #include <cstddef>
-#include <botan/bigint.h>
 
 namespace ember {
 

--- a/src/gateway/PacketCrypto.h
+++ b/src/gateway/PacketCrypto.h
@@ -18,14 +18,14 @@
 namespace ember {
 
 class PacketCrypto {
-	Botan::SecureVector<Botan::byte> key_;
+	Botan::secure_vector<Botan::byte> key_;
 	std::uint8_t send_i_ = 0;
 	std::uint8_t send_j_ = 0;
 	std::uint8_t recv_i_ = 0;
 	std::uint8_t recv_j_ = 0;
 
 public:
-	void set_key(const Botan::SecureVector<Botan::byte>& key) {
+	void set_key(const Botan::secure_vector<Botan::byte>& key) {
 		key_ = key;
 	}
 

--- a/src/gateway/PacketCrypto.h
+++ b/src/gateway/PacketCrypto.h
@@ -18,14 +18,14 @@
 namespace ember {
 
 class PacketCrypto {
-	Botan::secure_vector<Botan::byte> key_;
+	std::vector<Botan::byte> key_;
 	std::uint8_t send_i_ = 0;
 	std::uint8_t send_j_ = 0;
 	std::uint8_t recv_i_ = 0;
 	std::uint8_t recv_j_ = 0;
 
 public:
-	void set_key(const Botan::secure_vector<Botan::byte>& key) {
+	void set_key(const std::vector<Botan::byte>& key) {
 		key_ = key;
 	}
 

--- a/src/gateway/states/Authentication.cpp
+++ b/src/gateway/states/Authentication.cpp
@@ -154,7 +154,7 @@ void send_addon_data(ClientContext* ctx, const protocol::CMSG_AUTH_SESSION& pack
 void prove_session(ClientContext* ctx, Botan::BigInt key, const protocol::CMSG_AUTH_SESSION& packet) {
 	LOG_TRACE_FILTER_GLOB(LF_NETWORK) << __func__ << LOG_ASYNC;
 
-	Botan::secure_vector<Botan::byte> k_bytes = Botan::BigInt::encode_locked(key);
+	Botan::secure_vector<Botan::byte> k_bytes = Botan::BigInt::encode(key);
 	std::uint32_t unknown = 0; // this is hardcoded to zero in the client
 
 	Botan::SHA_160 hasher;

--- a/src/gateway/states/Authentication.cpp
+++ b/src/gateway/states/Authentication.cpp
@@ -154,7 +154,7 @@ void send_addon_data(ClientContext* ctx, const protocol::CMSG_AUTH_SESSION& pack
 void prove_session(ClientContext* ctx, Botan::BigInt key, const protocol::CMSG_AUTH_SESSION& packet) {
 	LOG_TRACE_FILTER_GLOB(LF_NETWORK) << __func__ << LOG_ASYNC;
 
-	Botan::secure_vector<Botan::byte> k_bytes = Botan::BigInt::encode(key);
+	std::vector<Botan::byte> k_bytes = Botan::BigInt::encode(key);
 	std::uint32_t unknown = 0; // this is hardcoded to zero in the client
 
 	Botan::SHA_160 hasher;

--- a/src/gateway/states/Authentication.cpp
+++ b/src/gateway/states/Authentication.cpp
@@ -154,7 +154,7 @@ void send_addon_data(ClientContext* ctx, const protocol::CMSG_AUTH_SESSION& pack
 void prove_session(ClientContext* ctx, Botan::BigInt key, const protocol::CMSG_AUTH_SESSION& packet) {
 	LOG_TRACE_FILTER_GLOB(LF_NETWORK) << __func__ << LOG_ASYNC;
 
-	Botan::SecureVector<Botan::byte> k_bytes = Botan::BigInt::encode(key);
+	Botan::secure_vector<Botan::byte> k_bytes = Botan::BigInt::encode_locked(key);
 	std::uint32_t unknown = 0; // this is hardcoded to zero in the client
 
 	Botan::SHA_160 hasher;
@@ -163,7 +163,7 @@ void prove_session(ClientContext* ctx, Botan::BigInt key, const protocol::CMSG_A
 	hasher.update_be(boost::endian::native_to_big(packet.seed));
 	hasher.update_be(boost::endian::native_to_big(ctx->auth_seed));
 	hasher.update(k_bytes);
-	Botan::SecureVector<Botan::byte> calc_hash = hasher.final();
+	Botan::secure_vector<Botan::byte> calc_hash = hasher.final();
 
 	if(calc_hash != packet.digest) {
 		LOG_DEBUG_GLOB << "Received bad digest from " << packet.username << LOG_ASYNC;

--- a/src/libs/game_protocol/include/game_protocol/client/CMSG_AUTH_SESSION.h
+++ b/src/libs/game_protocol/include/game_protocol/client/CMSG_AUTH_SESSION.h
@@ -39,7 +39,7 @@ public:
 		std::uint32_t update_url_crc;
 	};
 
-	Botan::SecureVector<Botan::byte> digest;
+	Botan::secure_vector<Botan::byte> digest;
 	std::uint32_t seed;
 	std::uint32_t id;
 	std::uint32_t security;
@@ -60,7 +60,7 @@ public:
 		stream >> seed;
 
 		digest.resize(DIGEST_LENGTH);
-		stream.get(digest.begin(), DIGEST_LENGTH);
+		stream.get(digest.data(), DIGEST_LENGTH);
 		
 		// handle compressed addon data
 		be::little_uint32_t decompressed_size;
@@ -122,7 +122,7 @@ public:
 		stream << be::native_to_little(unk1);
 		stream << username;
 		stream << be::native_to_little(seed);
-		stream.put(digest.begin(), digest.size());
+		stream.put(digest.data(), digest.size());
 	}
 
 	void set_size(std::uint16_t size) {

--- a/src/libs/shared/shared/util/FileMD5.cpp
+++ b/src/libs/shared/shared/util/FileMD5.cpp
@@ -16,7 +16,7 @@ namespace ember { namespace util {
 
 Botan::secure_vector<Botan::byte> generate_md5(const char* data, const std::size_t len) {
 	Botan::MD5 hasher;
-	return hasher.process(reinterpret_cast<const Botan::byte*>(data), len);
+	return hasher.process(data);
 }
 
 Botan::secure_vector<Botan::byte> generate_md5(const std::string& file) {
@@ -36,7 +36,7 @@ Botan::secure_vector<Botan::byte> generate_md5(const std::string& file) {
 	while(remaining) {
 		std::size_t read_size = remaining >= block_size? block_size : remaining;
 		stream.read(buffer.data(), read_size);
-		hasher.update(reinterpret_cast<const Botan::byte*>(buffer.data()), read_size);
+		hasher.update(buffer.data());
 		remaining -= read_size;
 
 		if(!stream.good()) {

--- a/src/libs/shared/shared/util/FileMD5.cpp
+++ b/src/libs/shared/shared/util/FileMD5.cpp
@@ -16,7 +16,7 @@ namespace ember { namespace util {
 
 Botan::secure_vector<Botan::byte> generate_md5(const char* data, const std::size_t len) {
 	Botan::MD5 hasher;
-	return hasher.process(data);
+	return hasher.process(reinterpret_cast<const Botan::byte*>(data), len);
 }
 
 Botan::secure_vector<Botan::byte> generate_md5(const std::string& file) {
@@ -36,7 +36,7 @@ Botan::secure_vector<Botan::byte> generate_md5(const std::string& file) {
 	while(remaining) {
 		std::size_t read_size = remaining >= block_size? block_size : remaining;
 		stream.read(buffer.data(), read_size);
-		hasher.update(buffer.data());
+		hasher.update(reinterpret_cast<const Botan::byte*>(buffer.data()), read_size);
 		remaining -= read_size;
 
 		if(!stream.good()) {

--- a/src/libs/shared/shared/util/FileMD5.cpp
+++ b/src/libs/shared/shared/util/FileMD5.cpp
@@ -14,12 +14,12 @@
 
 namespace ember { namespace util {
 
-Botan::SecureVector<Botan::byte> generate_md5(const char* data, const std::size_t len) {
+Botan::secure_vector<Botan::byte> generate_md5(const char* data, const std::size_t len) {
 	Botan::MD5 hasher;
 	return hasher.process(reinterpret_cast<const Botan::byte*>(data), len);
 }
 
-Botan::SecureVector<Botan::byte> generate_md5(const std::string& file) {
+Botan::secure_vector<Botan::byte> generate_md5(const std::string& file) {
 	std::ifstream stream(file, std::ios::in | std::ios::binary | std::ios::ate);
 
 	if(!stream.is_open()) {

--- a/src/libs/shared/shared/util/FileMD5.h
+++ b/src/libs/shared/shared/util/FileMD5.h
@@ -11,7 +11,7 @@
 
 namespace ember { namespace util {
 
-Botan::SecureVector<Botan::byte> generate_md5(const char* data, const std::size_t len);
-Botan::SecureVector<Botan::byte> generate_md5(const std::string& file);
+Botan::secure_vector<Botan::byte> generate_md5(const char* data, const std::size_t len);
+Botan::secure_vector<Botan::byte> generate_md5(const std::string& file);
 
 }} // util, ember

--- a/src/libs/srp6/include/srp6/Util.h
+++ b/src/libs/srp6/include/srp6/Util.h
@@ -17,16 +17,16 @@
  
 namespace ember { namespace srp6 {
 	
-BOOST_STRONG_TYPEDEF(Botan::SecureVector<Botan::byte>, SessionKey);
+BOOST_STRONG_TYPEDEF(Botan::secure_vector<Botan::byte>, SessionKey);
 
 enum class Compliance { RFC5054, GAME };
 
 namespace detail {
 
-Botan::SecureVector<Botan::byte> interleaved_hash(Botan::SecureVector<Botan::byte> hash);
-Botan::SecureVector<Botan::byte> encode_flip(const Botan::BigInt& val);
-Botan::SecureVector<Botan::byte> encode_flip_1363(const Botan::BigInt& val, std::size_t padding);
-Botan::BigInt decode_flip(Botan::SecureVector<Botan::byte> val);
+Botan::secure_vector<Botan::byte> interleaved_hash(Botan::secure_vector<Botan::byte> hash);
+Botan::secure_vector<Botan::byte> encode_flip(const Botan::BigInt& val);
+Botan::secure_vector<Botan::byte> encode_flip_1363(const Botan::BigInt& val, std::size_t padding);
+Botan::BigInt decode_flip(Botan::secure_vector<Botan::byte> val);
 Botan::BigInt scrambler(const Botan::BigInt& A, const Botan::BigInt& B, std::size_t padding,
                         Compliance mode);
 Botan::BigInt compute_k(const Botan::BigInt& g, const Botan::BigInt& N);

--- a/src/libs/srp6/include/srp6/Util.h
+++ b/src/libs/srp6/include/srp6/Util.h
@@ -17,15 +17,16 @@
  
 namespace ember { namespace srp6 {
 	
-BOOST_STRONG_TYPEDEF(Botan::secure_vector<Botan::byte>, SessionKey);
+BOOST_STRONG_TYPEDEF(std::vector<Botan::byte>, SessionKey);
 
 enum class Compliance { RFC5054, GAME };
 
 namespace detail {
 
-Botan::secure_vector<Botan::byte> interleaved_hash(Botan::secure_vector<Botan::byte> hash);
-Botan::secure_vector<Botan::byte> encode_flip(const Botan::BigInt& val);
+std::vector<Botan::byte> interleaved_hash(std::vector<Botan::byte> hash);
+std::vector<Botan::byte> encode_flip(const Botan::BigInt& val);
 Botan::secure_vector<Botan::byte> encode_flip_1363(const Botan::BigInt& val, std::size_t padding);
+Botan::BigInt decode_flip(std::vector<Botan::byte> val);
 Botan::BigInt decode_flip(Botan::secure_vector<Botan::byte> val);
 Botan::BigInt scrambler(const Botan::BigInt& A, const Botan::BigInt& B, std::size_t padding,
                         Compliance mode);

--- a/src/libs/srp6/src/Client.cpp
+++ b/src/libs/srp6/src/Client.cpp
@@ -14,7 +14,7 @@
 #include <utility>
 
 using Botan::BigInt;
-using Botan::SecureVector;
+using Botan::secure_vector;
 using Botan::power_mod;
 using Botan::AutoSeeded_RNG;
 
@@ -27,7 +27,7 @@ Client::Client(std::string identifier, std::string password, Generator gen, std:
 Client::Client(std::string identifier, std::string password, Generator gen, BigInt a, bool srp6a)
                : identifier_(std::move(identifier)), password_(std::move(password)),
                  gen_(std::move(gen)), a_(a) {
-	A_ = gen(a_) /* % N */;
+	A_ = gen_(a_) /* % N */;
 
 	if(srp6a) {
 		k_ = std::move(detail::compute_k(gen_.generator(), gen_.prime()));
@@ -58,7 +58,7 @@ SessionKey Client::session_key(const BigInt& B, const Botan::BigInt& salt, Compl
 	BigInt x = detail::compute_x(identifier_, password_, salt, mode);
 	BigInt S = power_mod((B - k_ * gen_(x)) % gen_.prime(), a_ + u * x, gen_.prime());
 	return interleave ? SessionKey(detail::interleaved_hash(detail::encode_flip(S)))
-	                    : SessionKey(Botan::BigInt::encode(S));
+	                    : SessionKey(Botan::BigInt::encode_locked(S));
 }
 
 BigInt Client::generate_proof(const SessionKey& key) const {

--- a/src/libs/srp6/src/Client.cpp
+++ b/src/libs/srp6/src/Client.cpp
@@ -58,7 +58,7 @@ SessionKey Client::session_key(const BigInt& B, const Botan::BigInt& salt, Compl
 	BigInt x = detail::compute_x(identifier_, password_, salt, mode);
 	BigInt S = power_mod((B - k_ * gen_(x)) % gen_.prime(), a_ + u * x, gen_.prime());
 	return interleave ? SessionKey(detail::interleaved_hash(detail::encode_flip(S)))
-	                    : SessionKey(Botan::BigInt::encode_locked(S));
+	                    : SessionKey(Botan::BigInt::encode(S));
 }
 
 BigInt Client::generate_proof(const SessionKey& key) const {

--- a/src/libs/srp6/src/Server.cpp
+++ b/src/libs/srp6/src/Server.cpp
@@ -47,7 +47,7 @@ SessionKey Server::session_key(const BigInt& A, Compliance mode, bool interleave
 	BigInt u = detail::scrambler(A, B_, N_.bytes(), mode);
 	BigInt S = power_mod(A * power_mod(v_, u, N_), b_, N_);
 	return interleave? SessionKey(detail::interleaved_hash(detail::encode_flip(S)))
-	                   : SessionKey(Botan::BigInt::encode_locked(S));
+	                   : SessionKey(Botan::BigInt::encode(S));
 }
 
 BigInt Server::generate_proof(const SessionKey& key, const BigInt& client_proof) const {

--- a/src/libs/srp6/src/Server.cpp
+++ b/src/libs/srp6/src/Server.cpp
@@ -47,7 +47,7 @@ SessionKey Server::session_key(const BigInt& A, Compliance mode, bool interleave
 	BigInt u = detail::scrambler(A, B_, N_.bytes(), mode);
 	BigInt S = power_mod(A * power_mod(v_, u, N_), b_, N_);
 	return interleave? SessionKey(detail::interleaved_hash(detail::encode_flip(S)))
-	                   : SessionKey(Botan::BigInt::encode(S));
+	                   : SessionKey(Botan::BigInt::encode_locked(S));
 }
 
 BigInt Server::generate_proof(const SessionKey& key, const BigInt& client_proof) const {

--- a/src/libs/srp6/src/Util.cpp
+++ b/src/libs/srp6/src/Util.cpp
@@ -47,13 +47,13 @@ std::vector<byte> interleaved_hash(std::vector<byte> hash) {
 	begin = std::distance(begin, hash.end()) % 2 == 0? begin : begin + 1;
 
 	auto bound = std::stable_partition(begin, hash.end(),
-		[&begin](const auto& x) { return (&x - begin.base()) % 2 == 0; });
+	    [&begin](const auto& x) { return (&x - &*begin) % 2 == 0; });
 
 	Botan::SHA_160 hasher;
-	secure_vector<byte> g(hasher.process(begin.base(), std::distance(begin, bound)));
-	secure_vector<byte> h(hasher.process(bound.base(), std::distance(bound, hash.end())));
-	std::vector<byte> final; //todo - when Botan 1.11 works on msvc, .reserve!
-	
+	secure_vector<byte> g(hasher.process(&*begin, std::distance(begin, bound)));
+	secure_vector<byte> h(hasher.process(&*bound, std::distance(bound, hash.end())));
+	std::vector<byte> final;
+
 	for(std::size_t i = 0, j = g.size(); i < j; ++i) {
 		final.push_back(g[i]);
 		final.push_back(h[i]);

--- a/src/login/AccountService.cpp
+++ b/src/login/AccountService.cpp
@@ -110,7 +110,7 @@ void AccountService::register_session(std::uint32_t account_id, const srp6::Sess
 	auto fbb = std::make_shared<flatbuffers::FlatBufferBuilder>();
 	auto uuid = generate_uuid();
 	auto uuid_bytes = fbb->CreateVector(uuid.begin(), uuid.static_size());
-	auto f_key = fbb->CreateVector(key.t.begin(), key.t.size());
+	auto f_key = fbb->CreateVector(key.t.data(), key.t.size());
 	auto msg = messaging::CreateMessageRoot(*fbb, messaging::Service::Account, uuid_bytes, 0,
 		em::Data::RegisterKey, em::account::CreateRegisterKey(*fbb, account_id, f_key).Union());
 	fbb->Finish(msg);

--- a/src/login/Authenticator.cpp
+++ b/src/login/Authenticator.cpp
@@ -54,7 +54,7 @@ ReconnectAuthenticator::ReconnectAuthenticator(std::string username, const Botan
 	// Usernames aren't required to be uppercase in the DB but the client requires it for calculations
 	std::transform(rcon_user_.begin(), rcon_user_.end(), rcon_user_.begin(), ::toupper);
 	salt_ = salt;
-	sess_key_ = Botan::BigInt::encode_locked(session_key);
+	sess_key_ = Botan::BigInt::encode(session_key);
 }
 
 bool ReconnectAuthenticator::proof_check(const grunt::client::ReconnectProof* packet) {

--- a/src/login/Authenticator.cpp
+++ b/src/login/Authenticator.cpp
@@ -49,12 +49,12 @@ srp6::SessionKey LoginAuthenticator::session_key() {
 }
 
 ReconnectAuthenticator::ReconnectAuthenticator(std::string username, const Botan::BigInt& session_key,
-                                               const Botan::SecureVector<Botan::byte>& salt)
+                                               const Botan::secure_vector<Botan::byte>& salt)
                                                : rcon_user_(std::move(username)) {
 	// Usernames aren't required to be uppercase in the DB but the client requires it for calculations
 	std::transform(rcon_user_.begin(), rcon_user_.end(), rcon_user_.begin(), ::toupper);
 	salt_ = salt;
-	sess_key_ = Botan::BigInt::encode(session_key);
+	sess_key_ = Botan::BigInt::encode_locked(session_key);
 }
 
 bool ReconnectAuthenticator::proof_check(const grunt::client::ReconnectProof* packet) {

--- a/src/login/Authenticator.h
+++ b/src/login/Authenticator.h
@@ -18,12 +18,12 @@ namespace ember {
 
 class ReconnectAuthenticator {
 	std::string rcon_user_;
-	Botan::SecureVector<Botan::byte> salt_;
+	Botan::secure_vector<Botan::byte> salt_;
 	srp6::SessionKey sess_key_;
 
 public:
 	ReconnectAuthenticator(std::string username, const Botan::BigInt& session_key,
-	                       const Botan::SecureVector<Botan::byte>& salt);
+	                       const Botan::secure_vector<Botan::byte>& salt);
 	bool proof_check(const grunt::client::ReconnectProof* proof);
 	std::string username() { return rcon_user_; }
 };

--- a/src/login/ExecutablesChecksum.cpp
+++ b/src/login/ExecutablesChecksum.cpp
@@ -20,7 +20,7 @@ Botan::secure_vector<Botan::byte> checksum(const Botan::secure_vector<Botan::byt
 	sha160.release(); // ctor didn't throw, relinquish the memory to Botan
 
 	hmac.set_key(seed);
-	hmac.update(reinterpret_cast<const Botan::byte*>(buffer->data()), buffer->size());
+	hmac.update(buffer->data());
 	return hmac.final();
 }
 

--- a/src/login/ExecutablesChecksum.cpp
+++ b/src/login/ExecutablesChecksum.cpp
@@ -14,18 +14,18 @@
 namespace ember { namespace client_integrity {
 
 Botan::secure_vector<Botan::byte> checksum(const Botan::secure_vector<Botan::byte>& seed,
-                                          const std::vector<char>* buffer) {
+                                           const std::vector<char>* buffer) {
 	auto sha160 = std::make_unique<Botan::SHA_160>();
 	Botan::HMAC hmac(sha160.get()); // Botan takes ownership
 	sha160.release(); // ctor didn't throw, relinquish the memory to Botan
 
 	hmac.set_key(seed);
-	hmac.update(buffer->data());
+	hmac.update(reinterpret_cast<const Botan::byte*>(buffer->data()), buffer->size());
 	return hmac.final();
 }
 
 Botan::secure_vector<Botan::byte> finalise(const Botan::secure_vector<Botan::byte>& checksum,
-                                          const std::uint8_t* client_seed, std::size_t len) {
+                                           const std::uint8_t* client_seed, std::size_t len) {
 	Botan::SHA_160 hasher;
 	hasher.update(client_seed, len);
 	hasher.update(checksum);

--- a/src/login/ExecutablesChecksum.cpp
+++ b/src/login/ExecutablesChecksum.cpp
@@ -13,7 +13,7 @@
 
 namespace ember { namespace client_integrity {
 
-Botan::SecureVector<Botan::byte> checksum(const Botan::SecureVector<Botan::byte>& seed,
+Botan::secure_vector<Botan::byte> checksum(const Botan::secure_vector<Botan::byte>& seed,
                                           const std::vector<char>* buffer) {
 	auto sha160 = std::make_unique<Botan::SHA_160>();
 	Botan::HMAC hmac(sha160.get()); // Botan takes ownership
@@ -24,7 +24,7 @@ Botan::SecureVector<Botan::byte> checksum(const Botan::SecureVector<Botan::byte>
 	return hmac.final();
 }
 
-Botan::SecureVector<Botan::byte> finalise(const Botan::SecureVector<Botan::byte>& checksum,
+Botan::secure_vector<Botan::byte> finalise(const Botan::secure_vector<Botan::byte>& checksum,
                                           const std::uint8_t* client_seed, std::size_t len) {
 	Botan::SHA_160 hasher;
 	hasher.update(client_seed, len);

--- a/src/login/ExecutablesChecksum.h
+++ b/src/login/ExecutablesChecksum.h
@@ -16,9 +16,9 @@
 namespace ember { namespace client_integrity {
 
 Botan::secure_vector<Botan::byte> checksum(const Botan::secure_vector<Botan::byte>& seed,
-                                          const std::vector<char>* buffer);
+                                           const std::vector<char>* buffer);
 
 Botan::secure_vector<Botan::byte> finalise(const Botan::secure_vector<Botan::byte>& checksum,
-                                          const std::uint8_t* seed, std::size_t len);
+                                           const std::uint8_t* seed, std::size_t len);
 
 }} // client_integrity, ember

--- a/src/login/ExecutablesChecksum.h
+++ b/src/login/ExecutablesChecksum.h
@@ -15,10 +15,10 @@
 
 namespace ember { namespace client_integrity {
 
-Botan::SecureVector<Botan::byte> checksum(const Botan::SecureVector<Botan::byte>& seed,
+Botan::secure_vector<Botan::byte> checksum(const Botan::secure_vector<Botan::byte>& seed,
                                           const std::vector<char>* buffer);
 
-Botan::SecureVector<Botan::byte> finalise(const Botan::SecureVector<Botan::byte>& checksum,
+Botan::secure_vector<Botan::byte> finalise(const Botan::secure_vector<Botan::byte>& checksum,
                                           const std::uint8_t* seed, std::size_t len);
 
 }} // client_integrity, ember

--- a/src/login/LoginHandler.cpp
+++ b/src/login/LoginHandler.cpp
@@ -325,7 +325,7 @@ bool LoginHandler::validate_pin(const grunt::client::LoginProof* packet) {
 
 bool LoginHandler::validate_client_integrity(const std::array<std::uint8_t, HASH_LENGTH>& hash,
                                              const Botan::BigInt& salt, bool reconnect) {
-	auto decoded = Botan::BigInt::encode_locked(salt);
+	auto decoded = Botan::BigInt::encode(salt);
 	std::reverse(decoded.begin(), decoded.end());
 	return validate_client_integrity(hash, decoded.data(), decoded.size(), reconnect);
 }

--- a/src/login/LoginHandler.cpp
+++ b/src/login/LoginHandler.cpp
@@ -325,9 +325,9 @@ bool LoginHandler::validate_pin(const grunt::client::LoginProof* packet) {
 
 bool LoginHandler::validate_client_integrity(const std::array<std::uint8_t, HASH_LENGTH>& hash,
                                              const Botan::BigInt& salt, bool reconnect) {
-	auto decoded = Botan::BigInt::encode(salt);
+	auto decoded = Botan::BigInt::encode_locked(salt);
 	std::reverse(decoded.begin(), decoded.end());
-	return validate_client_integrity(hash, decoded.begin(), decoded.size(), reconnect);
+	return validate_client_integrity(hash, decoded.data(), decoded.size(), reconnect);
 }
 
 bool LoginHandler::validate_client_integrity(const std::array<std::uint8_t, HASH_LENGTH>& client_hash,
@@ -347,11 +347,11 @@ bool LoginHandler::validate_client_integrity(const std::array<std::uint8_t, HASH
 		return false;
 	}
 
-	Botan::SecureVector<Botan::byte> hash;
+	Botan::secure_vector<Botan::byte> hash;
 
 	// client doesn't bother to checksum the binaries on reconnect, it just hashes the salt (=])
 	if(reconnect) {
-		Botan::SecureVector<Botan::byte> checksum(HASH_LENGTH); // all-zero hash
+		Botan::secure_vector<Botan::byte> checksum(HASH_LENGTH); // all-zero hash
 		hash = client_integrity::finalise(checksum, salt, len);
 	} else {
 		auto checksum = client_integrity::checksum(checksum_salt_, *data);

--- a/src/login/LoginHandler.h
+++ b/src/login/LoginHandler.h
@@ -73,7 +73,7 @@ class LoginHandler {
 	std::unique_ptr<LoginAuthenticator> login_auth_;
 	std::unique_ptr<ReconnectAuthenticator> reconn_auth_;
 	std::unordered_map<std::uint32_t, std::uint32_t> char_count_;
-	Botan::SecureVector<Botan::byte> checksum_salt_;
+	Botan::secure_vector<Botan::byte> checksum_salt_;
 	grunt::client::LoginChallenge challenge_;
 	TransferState transfer_state_;
 

--- a/src/login/grunt/client/LoginProof.h
+++ b/src/login/grunt/client/LoginProof.h
@@ -171,13 +171,13 @@ public:
 	void write_to_stream(spark::BinaryStream& stream) const override {
 		stream << opcode;
 
-		Botan::SecureVector<Botan::byte> bytes = Botan::BigInt::encode_1363(A, A_LENGTH);
+		Botan::secure_vector<Botan::byte> bytes = Botan::BigInt::encode_1363(A, A_LENGTH);
 		std::reverse(std::begin(bytes), std::end(bytes));
-		stream.put(bytes.begin(), bytes.size());
+		stream.put(bytes.data(), bytes.size());
 
 		bytes = Botan::BigInt::encode_1363(M1, M1_LENGTH);
 		std::reverse(std::begin(bytes), std::end(bytes));
-		stream.put(bytes.begin(), bytes.size());
+		stream.put(bytes.data(), bytes.size());
 
 		stream.put(client_checksum.data(), client_checksum.size());
 

--- a/src/login/grunt/server/LoginChallenge.h
+++ b/src/login/grunt/server/LoginChallenge.h
@@ -133,9 +133,9 @@ public:
 			return; // don't send the rest of the fields
 		}
 		
-		Botan::SecureVector<Botan::byte> bytes = Botan::BigInt::encode_1363(B, PUB_KEY_LENGTH);
+		Botan::secure_vector<Botan::byte> bytes = Botan::BigInt::encode_1363(B, PUB_KEY_LENGTH);
 		std::reverse(std::begin(bytes), std::end(bytes));
-		stream.put(bytes.begin(), bytes.size());
+		stream.put(bytes.data(), bytes.size());
 
 		stream << g_len;
 		stream << g;
@@ -143,11 +143,11 @@ public:
 
 		bytes = Botan::BigInt::encode_1363(N, PRIME_LENGTH);
 		std::reverse(std::begin(bytes), std::end(bytes));
-		stream.put(bytes.begin(), bytes.size());
+		stream.put(bytes.data(), bytes.size());
 
 		bytes = Botan::BigInt::encode_1363(s, SALT_LENGTH);
 		std::reverse(std::begin(bytes), std::end(bytes));
-		stream.put(bytes.begin(), bytes.size());
+		stream.put(bytes.data(), bytes.size());
 
 		stream.put(checksum_salt.data(), checksum_salt.size());
 		stream << two_factor_auth;

--- a/src/login/grunt/server/LoginProof.h
+++ b/src/login/grunt/server/LoginProof.h
@@ -93,9 +93,9 @@ public:
 			return;
 		}
 
-		Botan::SecureVector<Botan::byte> bytes = Botan::BigInt::encode_1363(M2, PROOF_LENGTH);
+		Botan::secure_vector<Botan::byte> bytes = Botan::BigInt::encode_1363(M2, PROOF_LENGTH);
 		std::reverse(std::begin(bytes), std::end(bytes));
-		stream.put(bytes.begin(), bytes.size());
+		stream.put(bytes.data(), bytes.size());
 		stream << be::native_to_little(survey_id);
 	
 	}

--- a/src/login/main.cpp
+++ b/src/login/main.cpp
@@ -101,9 +101,6 @@ void launch(const po::variables_map& args, el::Logger* logger) try {
 	LOG_WARN(logger) << "Compiled with DEBUG_NO_THREADS!" << LOG_SYNC;
 #endif
 
-	LOG_INFO(logger) << "Initialialising Botan..." << LOG_SYNC;
-	Botan::LibraryInitializer init("thread_safe");
-
 	LOG_INFO(logger) << "Seeding xorshift RNG..." << LOG_SYNC;
 	Botan::AutoSeeded_RNG rng;
 	rng.randomize(reinterpret_cast<Botan::byte*>(ember::rng::xorshift::seed),

--- a/src/login/main.cpp
+++ b/src/login/main.cpp
@@ -35,7 +35,6 @@
 #include <shared/database/daos/UserDAO.h>
 #include <shared/IPBanCache.h>
 #include <shared/util/xoroshiro128plus.h>
-#include <botan/init.h>
 #include <botan/version.h>
 #include <boost/asio/io_service.hpp>
 #include <boost/version.hpp>


### PR DESCRIPTION
This also uses std::vector<byte> instead of Botan::secure_vector<byte>.