### PR TITLE
Clang warnings, Also change MetricsImpl::gauge function to use enums for adjustment.

### DIFF
--- a/src/gateway/ClientHandler.cpp
+++ b/src/gateway/ClientHandler.cpp
@@ -37,6 +37,8 @@ void ClientHandler::handle_packet(protocol::ClientHeader header, spark::Buffer& 
 			return;
 		case protocol::ClientOpcodes::CMSG_KEEP_ALIVE: // no response required
 			return;
+		default:
+			break;
 	}
 
 	update_packet[context_.state](&context_);

--- a/src/gateway/RealmService.cpp
+++ b/src/gateway/RealmService.cpp
@@ -29,6 +29,8 @@ void RealmService::handle_message(const spark::Link& link, const em::MessageRoot
 		case em::Data::RequestRealmStatus:
 			send_realm_status(link, root);
 			break;
+		default:
+			break;
 	}
 }
 

--- a/src/gateway/states/Authentication.cpp
+++ b/src/gateway/states/Authentication.cpp
@@ -234,6 +234,8 @@ void handle_event(ClientContext* ctx, const Event* event) {
 		case EventType::SESSION_KEY_RESPONSE:
 			handle_session_key(ctx, static_cast<const SessionKeyResponse*>(event));
 			break;
+		default:
+			break;
 	}
 }
 

--- a/src/gateway/states/CharacterList.cpp
+++ b/src/gateway/states/CharacterList.cpp
@@ -243,6 +243,8 @@ void handle_event(ClientContext* ctx, const Event* event) {
 		case EventType::CHAR_RENAME_RESPONSE:
 			character_rename_completion(ctx, static_cast<const CharRenameResponse*>(event));
 			break;
+		default:
+			break;
 	}
 }
 

--- a/src/gateway/states/InQueue.cpp
+++ b/src/gateway/states/InQueue.cpp
@@ -44,6 +44,8 @@ void handle_event(ClientContext* ctx, const Event* event) {
 		case EventType::QUEUE_SUCCESS:
 			handle_queue_success(ctx, static_cast<const QueueSuccess*>(event));
 			break;
+		default:
+			break;
 	}
 }
 

--- a/src/libs/shared/shared/metrics/Metrics.h
+++ b/src/libs/shared/shared/metrics/Metrics.h
@@ -18,7 +18,7 @@ class Metrics {
 public:
 	virtual void increment(const char* key, std::intmax_t value = 1) { }
 	virtual void timing(const char* key, std::chrono::milliseconds value) { }
-	virtual void gauge(const char* key, std::size_t value, bool adjust = false) { }
+	virtual void gauge(const char* key, std::intmax_t value, bool adjust = false) { }
 	virtual void set(const char* key, std::intmax_t value) { }
 	virtual ~Metrics() = default;
 };

--- a/src/libs/shared/shared/metrics/Metrics.h
+++ b/src/libs/shared/shared/metrics/Metrics.h
@@ -16,9 +16,11 @@ namespace ember {
 
 class Metrics {
 public:
+	enum Adjustment { NONE, POSITIVE, NEGATIVE };
+
 	virtual void increment(const char* key, std::intmax_t value = 1) { }
 	virtual void timing(const char* key, std::chrono::milliseconds value) { }
-	virtual void gauge(const char* key, std::intmax_t value, bool adjust = false) { }
+	virtual void gauge(const char* key, std::uintmax_t value, Adjustment adjustment = Adjustment::NONE) { }
 	virtual void set(const char* key, std::intmax_t value) { }
 	virtual ~Metrics() = default;
 };

--- a/src/libs/shared/shared/metrics/MetricsImpl.cpp
+++ b/src/libs/shared/shared/metrics/MetricsImpl.cpp
@@ -44,13 +44,7 @@ void MetricsImpl::timing(const char* key, std::chrono::milliseconds value) {
 
 void MetricsImpl::gauge(const char* key, std::size_t value, bool adjust) {
 	std::stringstream format;
-	format << key << ":";
-
-	if(adjust) {
-		format << (value >= 0? "+" : "-");
-	}
-
-	format << value << "|g";
+	format << key << ":" << value << "|g";
  	send(format.str());
 }
 

--- a/src/libs/shared/shared/metrics/MetricsImpl.cpp
+++ b/src/libs/shared/shared/metrics/MetricsImpl.cpp
@@ -42,10 +42,17 @@ void MetricsImpl::timing(const char* key, std::chrono::milliseconds value) {
  	send(format.str());
 }
 
-void MetricsImpl::gauge(const char* key, std::size_t value, bool adjust) {
+void MetricsImpl::gauge(const char* key, std::intmax_t value, bool adjust) {
 	std::stringstream format;
-	format << key << ":" << value << "|g";
- 	send(format.str());
+	format << key << ":";
+
+	if(adjust) {
+		format << (value >= 0? "+" : "-");
+	}
+
+	format << value << "|g";
+
+	send(format.str());
 }
 
 void MetricsImpl::set(const char* key, std::intmax_t value) {

--- a/src/libs/shared/shared/metrics/MetricsImpl.cpp
+++ b/src/libs/shared/shared/metrics/MetricsImpl.cpp
@@ -39,15 +39,20 @@ void MetricsImpl::increment(const char* key, std::intmax_t value) {
 void MetricsImpl::timing(const char* key, std::chrono::milliseconds value) {
 	std::stringstream format;
 	format << key << ":" << value.count() << "|ms";
- 	send(format.str());
+	send(format.str());
 }
 
-void MetricsImpl::gauge(const char* key, std::intmax_t value, bool adjust) {
+void MetricsImpl::gauge(const char* key, std::uintmax_t value, Adjustment adjustment) {
 	std::stringstream format;
 	format << key << ":";
 
-	if(adjust) {
-		format << (value >= 0? "+" : "-");
+	switch (adjustment) {
+		case Adjustment::POSITIVE: format << "+";
+			break;
+		case Adjustment::NEGATIVE: format << "-";
+			break;
+		default:
+			break;
 	}
 
 	format << value << "|g";
@@ -58,7 +63,7 @@ void MetricsImpl::gauge(const char* key, std::intmax_t value, bool adjust) {
 void MetricsImpl::set(const char* key, std::intmax_t value) {
 	std::stringstream format;
 	format << key << ":" << value << "|s";
- 	send(format.str());
+	send(format.str());
 }
 
 void MetricsImpl::send(std::string message) {

--- a/src/libs/shared/shared/metrics/MetricsImpl.h
+++ b/src/libs/shared/shared/metrics/MetricsImpl.h
@@ -29,7 +29,7 @@ public:
 
 	void increment(const char* key, std::intmax_t value = 1) override;
 	void timing(const char* key, std::chrono::milliseconds value) override;
-	void gauge(const char* key, std::size_t value, bool adjust = false) override;
+    void gauge(const char* key, std::intmax_t value, bool adjust = false) override;
 	void set(const char* key, std::intmax_t value) override;
 };
 

--- a/src/libs/shared/shared/metrics/MetricsImpl.h
+++ b/src/libs/shared/shared/metrics/MetricsImpl.h
@@ -29,7 +29,7 @@ public:
 
 	void increment(const char* key, std::intmax_t value = 1) override;
 	void timing(const char* key, std::chrono::milliseconds value) override;
-    void gauge(const char* key, std::intmax_t value, bool adjust = false) override;
+	void gauge(const char* key, std::uintmax_t value, Adjustment adjustment = Adjustment::NONE) override;
 	void set(const char* key, std::intmax_t value) override;
 };
 

--- a/src/libs/spark/include/spark/buffers/ChainedBuffer.h
+++ b/src/libs/spark/include/spark/buffers/ChainedBuffer.h
@@ -304,7 +304,7 @@ public:
 		return (*buffer)[offset_index % BlockSize];
 	}
 
-	char& operator[](const std::size_t index) {
+	char& operator[](const std::size_t index) override {
 		return const_cast<char&>(static_cast<const ChainedBuffer<BlockSize>&>(*this)[index]);
 	}
 

--- a/src/login/LoginHandler.cpp
+++ b/src/login/LoginHandler.cpp
@@ -743,6 +743,8 @@ void LoginHandler::on_chunk_complete() {
 			case State::PATCH_TRANSFER:
 				state_ = State::CLOSED;
 				break;
+			default:
+				break;
 		}
 	} else {
 		transfer_chunk();

--- a/src/login/LoginSession.cpp
+++ b/src/login/LoginSession.cpp
@@ -31,7 +31,7 @@ LoginSession::LoginSession(SessionManager& sessions, boost::asio::ip::tcp::socke
 		write_chain(packet, true);
 	};
 
-	handler_.execute_async = [&](auto& action) {
+	handler_.execute_async = [&](auto action) {
 		execute_async(action);
 	};
 }


### PR DESCRIPTION
Warnings/Error fixed:
* This fixes the compile issue mentioned in #12 (`error: no viable overloaded '='`)
* Adds missing defaults for switch states
* Rollback the function `MetricsImpl::gauge` cause unsigned ints cannot be below zero (logical error)

Things this PR dosent cover:
* `warning: multi-character character constant [-Wmultichar]` in Magic.h
* `warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]` for most Log messages (like in CharacterHandler.cpp etc)
* `error: pragma message requires parenthesized string` in Affinity.cpp (#pragma message WARN). This currently need to be commented out otherwise the compile fails.
* `warning: #pragma once in main file [-Wpragma-once-outside-header]`