### PR TITLE
Add optional reference counting to TLS allocator

### DIFF
--- a/src/libs/spark/include/spark/buffers/DynamicBuffer.h
+++ b/src/libs/spark/include/spark/buffers/DynamicBuffer.h
@@ -32,21 +32,19 @@ class BufferSequence;
 template<decltype(auto) BlockSize>
 concept int_gt_zero = std::integral<decltype(BlockSize)> && BlockSize > 0;
 
-template<
-	decltype(auto) BlockSize,
+template<decltype(auto) BlockSize,
 	byte_type StorageValueType = std::byte,
 	typename Allocator = DefaultAllocator<detail::IntrusiveStorage<BlockSize, StorageValueType>>
 >
 requires int_gt_zero<BlockSize>
 class DynamicBuffer final : public pmr::Buffer {
-	using Storage = IntrusiveStorage<BlockSize, StorageValueType>;
-
 public:
-	using value_type = StorageValueType;
-	using node_type  = IntrusiveNode;
-	using size_type  = std::size_t;
-	using contiguous = is_non_contiguous;
-	using seeking    = supported;
+	using storage_type = typename IntrusiveStorage<BlockSize, StorageValueType>;
+	using value_type   = StorageValueType;
+	using node_type    = IntrusiveNode;
+	using size_type    = std::size_t;
+	using contiguous   = is_non_contiguous;
+	using seeking      = supported;
 
 	static constexpr size_type npos = -1;
 
@@ -66,9 +64,9 @@ private:
 		node->prev->next = node->next;
 	}
 
-	inline Storage* buffer_from_node(const IntrusiveNode* node) const {
-		return reinterpret_cast<Storage*>(std::uintptr_t(node)
-			- offsetof(Storage, node));
+	inline storage_type* buffer_from_node(const IntrusiveNode* node) const {
+		return reinterpret_cast<storage_type*>(std::uintptr_t(node)
+			- offsetof(storage_type, node));
 	}
 
 	void move(DynamicBuffer& rhs) noexcept {
@@ -107,7 +105,7 @@ private:
 	}
 	
 #ifdef BUFFER_DEBUG
-	void offset_buffers(std::vector<Storage*>& buffers, size_type offset) {
+	void offset_buffers(std::vector<storage_type*>& buffers, size_type offset) {
 		std::erase_if(buffers, [&](auto block) {
 			if(block->size() > offset) {
 				block->read_offset += offset;
@@ -146,11 +144,11 @@ private:
 		}
 	}
 
-	[[nodiscard]] Storage* allocate() {
+	[[nodiscard]] storage_type* allocate() {
 		return allocator_.allocate();
 	}
 
-	void deallocate(Storage* buffer) {
+	void deallocate(storage_type* buffer) {
 		allocator_.deallocate(buffer);
 	}
 
@@ -230,11 +228,11 @@ public:
 	}
 
 #ifdef BUFFER_DEBUG
-	std::vector<Storage*> fetch_buffers(const size_type length,
+	std::vector<storage_type*> fetch_buffers(const size_type length,
 	                                             const size_type offset = 0) {
 		size_type total = length + offset;
 		BOOST_ASSERT_MSG(total <= size_, "Chained buffer fetch too large!");
-		std::vector<Storage*> buffers;
+		std::vector<storage_type*> buffers;
 		auto head = root_.next;
 
 		while(total) {
@@ -285,7 +283,7 @@ public:
 		IntrusiveNode* tail = root_.prev;
 
 		do {
-			Storage* buffer;
+			storage_type* buffer;
 
 			if(tail != &root_) [[likely]] {
 				buffer = buffer_from_node(tail);
@@ -310,7 +308,7 @@ public:
 		IntrusiveNode* tail = root_.prev;
 
 		do {
-			Storage* buffer;
+			storage_type* buffer;
 
 			if(tail == &root_) [[unlikely]] {
 				buffer = allocate();
@@ -331,7 +329,7 @@ public:
 		return size_;
 	}
 
-	Storage* back() const {
+	storage_type* back() const {
 		if(root_.prev == &root_) {
 			return nullptr;
 		}
@@ -339,7 +337,7 @@ public:
 		return buffer_from_node(root_.prev);
 	}
 
-	Storage* front() const {
+	storage_type* front() const {
 		if(root_.next == &root_) {
 			return nullptr;
 		}
@@ -354,7 +352,7 @@ public:
 		return buffer;
 	}
 
-	void push_back(Storage* buffer) {
+	void push_back(storage_type* buffer) {
 		link_tail_node(&buffer->node);
 		size_ += buffer->write_offset;
 	}

--- a/src/libs/spark/include/spark/buffers/DynamicBuffer.h
+++ b/src/libs/spark/include/spark/buffers/DynamicBuffer.h
@@ -39,7 +39,7 @@ template<decltype(auto) BlockSize,
 requires int_gt_zero<BlockSize>
 class DynamicBuffer final : public pmr::Buffer {
 public:
-	using storage_type = typename IntrusiveStorage<BlockSize, StorageValueType>;
+	using storage_type = IntrusiveStorage<BlockSize, StorageValueType>;
 	using value_type   = StorageValueType;
 	using node_type    = IntrusiveNode;
 	using size_type    = std::size_t;

--- a/src/libs/spark/include/spark/buffers/DynamicTLSBuffer.h
+++ b/src/libs/spark/include/spark/buffers/DynamicTLSBuffer.h
@@ -33,7 +33,12 @@ template<decltype(auto) BlockSize,
 	typename EnrantPolicy = SafeEntrant,
 	typename StorageType = std::byte>
 using DynamicTLSBuffer = DynamicBuffer<BlockSize, StorageType,
-	TLSBlockAllocator<detail::IntrusiveStorage<BlockSize>, count, EnrantPolicy>
+	TLSBlockAllocator<
+		typename DynamicBuffer<BlockSize>::storage_type,
+		count,
+		ThreadLifetime,
+		EnrantPolicy
+	>
 >;
 
 } // io, spark, ember

--- a/src/libs/spark/include/spark/buffers/allocators/TLSBlockAllocator.h
+++ b/src/libs/spark/include/spark/buffers/allocators/TLSBlockAllocator.h
@@ -208,23 +208,33 @@ public:
 
 } // unnamed
 
-struct EntrantPolicy{};
-struct SafeEntrant : EntrantPolicy{};
-struct UnsafeEntrant : EntrantPolicy{};
+struct EntrantTag{};
+struct SafeEntrant : EntrantTag{};
+struct UnsafeEntrant : EntrantTag{};
+
+struct RefCountTag{};
+struct RefCounted: RefCountTag{};
+struct ThreadLifetime : RefCountTag{};
 
 template<typename _ty,
 	std::size_t _elements,
-	std::derived_from<EntrantPolicy> entrant = SafeEntrant,
+	std::derived_from<RefCountTag> RefCount = ThreadLifetime,
+	std::derived_from<EntrantTag> Entrant = SafeEntrant,
 	PagePolicy policy = PagePolicy::lock
 >
 class TLSBlockAllocator final {
+	using RefCountType = std::conditional<
+		std::is_same_v<RefCount, RefCounted>, int, std::monostate
+	>::type;
+
 	using AllocatorType = Allocator<_ty, _elements, policy, enforce_same>;
 
 	static inline thread_local std::unique_ptr<AllocatorType> allocator_;
+	static inline thread_local RefCountType ref_count_{};
 
 	// Compiler will optimise calls to this out when using UnsafeEntrant
 	inline void initialise() {
-		if constexpr(std::is_same_v<entrant, SafeEntrant>) {
+		if constexpr(std::is_same_v<Entrant, SafeEntrant>) {
 			if(!allocator_) {
 				allocator_ = std::make_unique<AllocatorType>();
 			}
@@ -239,6 +249,10 @@ public:
 #endif
 
 	TLSBlockAllocator() {
+		if constexpr(std::is_same_v<RefCount, RefCounted>) {
+			++ref_count_;
+		}
+
 		thread_enter();
 	}
 
@@ -284,11 +298,21 @@ public:
 		initialise();
 		return allocator_.get();
 	}
+#endif
 
 	~TLSBlockAllocator() {
+		if constexpr(std::is_same_v<RefCount, RefCounted>) {
+			--ref_count_;
+
+			if(ref_count_ == 0) {
+				allocator_.reset();
+			}
+		}
+
+#ifdef _DEBUG_TLS_BLOCK_ALLOCATOR
 		assert(active_allocs == 0);
-	}
 #endif
+	}
 };
 
 } // io, spark, ember

--- a/src/libs/spark/include/spark/buffers/allocators/TLSBlockAllocator.h
+++ b/src/libs/spark/include/spark/buffers/allocators/TLSBlockAllocator.h
@@ -26,9 +26,9 @@
 
 namespace ember::spark::io {
 
-enum class PagePolicy {
-	no_lock, lock
-};
+struct PageLockTag{};
+struct PageLock : PageLockTag{};
+struct NoPageLock : PageLockTag{};
 
 namespace {
 
@@ -42,9 +42,9 @@ concept gt_zero = size > 0;
 template<typename T, typename U>
 concept sizeof_gte = sizeof(T) >= sizeof(U);
 
-struct thread_tag{};
-struct enforce_same : thread_tag{};
-struct no_thread_policy: thread_tag{};
+struct ValidateTag{};
+struct Validate : ValidateTag{};
+struct NoValidate : ValidateTag{};
 
 /*
  * Basic fixed-size block stack allocator that preallocates a slab of memory
@@ -66,13 +66,13 @@ struct no_thread_policy: thread_tag{};
  * implementing the functionality there is messier (and slower).
  */
 template<typename _ty, std::size_t _elements,
-	PagePolicy _policy = PagePolicy::no_lock,
-	std::derived_from<thread_tag> ThreadPolicy = no_thread_policy
+	std::derived_from<PageLockTag> PageLockPolicy = NoPageLock,
+	std::derived_from<ValidateTag> ValidationPolicy = NoValidate
 >
 requires gt_zero<_elements> && sizeof_gte<_ty, FreeBlock>
 class Allocator {
 	using tid_type = std::conditional<
-		std::is_same_v<ThreadPolicy, enforce_same>, std::thread::id, std::monostate
+		std::is_same_v<ValidationPolicy, Validate>, std::thread::id, std::monostate
 	>::type;
 
 	struct Block {
@@ -91,7 +91,7 @@ class Allocator {
 	std::array<char, block_size * _elements> storage_;
 
 	void initialise() {
-		if constexpr(_policy == PagePolicy::lock) {
+		if constexpr(std::is_same_v<PageLockPolicy, PageLock>) {
 			util::page_lock(storage_.data(), storage_.size());
 		}
 
@@ -131,7 +131,7 @@ public:
 	std::size_t total_deallocs = 0;
 #endif
 
-	Allocator()	requires requires { std::is_same_v<ThreadPolicy, enforce_same>; }
+	Allocator()	requires std::same_as<ValidationPolicy, Validate>
 		: thread_id_(std::this_thread::get_id()) {
 		initialise();
 	}
@@ -157,7 +157,7 @@ public:
 			block->meta.using_new = true;
 		}
 
-		if constexpr(std::is_same_v<ThreadPolicy, enforce_same>) {
+		if constexpr(std::is_same_v<ValidationPolicy, Validate>) {
 			block->meta.thread_id = thread_id_;
 		}
 
@@ -171,7 +171,7 @@ public:
 		assert(t);
 		auto block = std::start_lifetime_as<Block>(t);
 
-		if constexpr(std::is_same_v<ThreadPolicy, enforce_same>) {
+		if constexpr(std::is_same_v<ValidationPolicy, Validate>) {
 			assert(block->meta.thread_id == thread_id_
 				&& "thread policy error or clobbered block");
 		}
@@ -196,7 +196,7 @@ public:
 	}
 
 	~Allocator() {
-		if constexpr(_policy == PagePolicy::lock) {
+		if constexpr(std::is_same_v<PageLockPolicy, PageLock>) {
 			util::page_unlock(storage_.data(), storage_.size());
 		}
 
@@ -212,29 +212,29 @@ struct EntrantTag{};
 struct SafeEntrant : EntrantTag{};
 struct UnsafeEntrant : EntrantTag{};
 
-struct RefCountTag{};
-struct RefCounted: RefCountTag{};
-struct ThreadLifetime : RefCountTag{};
+struct LifetimeTag{};
+struct RefCounting : LifetimeTag{};
+struct ThreadLifetime : LifetimeTag{};
 
 template<typename _ty,
 	std::size_t _elements,
-	std::derived_from<RefCountTag> RefCount = ThreadLifetime,
-	std::derived_from<EntrantTag> Entrant = SafeEntrant,
-	PagePolicy policy = PagePolicy::lock
+	std::derived_from<LifetimeTag> LifetimePolicy = ThreadLifetime,
+	std::derived_from<EntrantTag> EntrantPolicy = SafeEntrant,
+	std::derived_from<PageLockTag> PageLockPolicy = NoPageLock
 >
 class TLSBlockAllocator final {
 	using RefCountType = std::conditional<
-		std::is_same_v<RefCount, RefCounted>, int, std::monostate
+		std::is_same_v<LifetimePolicy, RefCounting>, int, std::monostate
 	>::type;
 
-	using AllocatorType = Allocator<_ty, _elements, policy, enforce_same>;
+	using AllocatorType = Allocator<_ty, _elements, PageLockPolicy, NoValidate>;
 
 	static inline thread_local std::unique_ptr<AllocatorType> allocator_;
 	static inline thread_local RefCountType ref_count_{};
 
 	// Compiler will optimise calls to this out when using UnsafeEntrant
 	inline void initialise() {
-		if constexpr(std::is_same_v<Entrant, SafeEntrant>) {
+		if constexpr(std::is_same_v<EntrantPolicy, SafeEntrant>) {
 			if(!allocator_) {
 				allocator_ = std::make_unique<AllocatorType>();
 			}
@@ -249,7 +249,7 @@ public:
 #endif
 
 	TLSBlockAllocator() {
-		if constexpr(std::is_same_v<RefCount, RefCounted>) {
+		if constexpr(std::is_same_v<LifetimePolicy, RefCounting>) {
 			++ref_count_;
 		}
 
@@ -301,7 +301,7 @@ public:
 #endif
 
 	~TLSBlockAllocator() {
-		if constexpr(std::is_same_v<RefCount, RefCounted>) {
+		if constexpr(std::is_same_v<LifetimePolicy, RefCounting>) {
 			--ref_count_;
 
 			if(ref_count_ == 0) {


### PR DESCRIPTION
Allows for deallocating once no more allocator frontends exist rather than waiting for thread exit