### PR TITLE
Update schemas/CMakeLists.txt for build_flatbuffers

### DIFF
--- a/schemas/CMakeLists.txt
+++ b/schemas/CMakeLists.txt
@@ -14,13 +14,13 @@ set(SERVICE_SCHEMAS
 )
 
 set(FB_SCHEMAS
-	${SERVICE_SCHEMAS}
+    ${SERVICE_SCHEMAS}
     ${CMAKE_CURRENT_SOURCE_DIR}/spark/Spark.fbs
     ${CMAKE_CURRENT_SOURCE_DIR}/packetlog/PacketLog.fbs
 )
 
 set(FLATC_ARGS "-b" "-c" "--gen-mutable" "--scoped-enums" "--schema" "--bfbs-comments" "--gen-object-api")
-build_flatbuffers("${FB_SCHEMAS}" ${CMAKE_CURRENT_SOURCE_DIR} ${FB_SCHEMA_TARGET_NAME} "" ${CMAKE_BINARY_DIR} "" "")
+build_flatbuffers("${FB_SCHEMAS}" ${CMAKE_CURRENT_SOURCE_DIR} ${FB_SCHEMA_TARGET_NAME} "" ${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR} "")
 
 set(TEMPLATE_DIR ${CMAKE_SOURCE_DIR}/src/tools/rpcgen/templates/)
 build_spark_services("${SERVICE_SCHEMAS}" ${TEMPLATE_DIR} ${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
Flatbuffers will throw a fit on macos if the schema is not specified to specifically build into the build folder.

The BuildFlatBuffers.cmake file creates custom commands for both generating C++ headers and generating binary schema files (the BFBS files). The portion that creates the BFBS files is wrapped in the following condition:

```
function(build_flatbuffers flatbuffers_schemas
                           schema_include_dirs
                           custom_target_name
                           additional_dependencies
                           generated_includes_dir
                           binary_schemas_dir
                           copy_text_schemas_dir)
  ...
  if (NOT ${binary_schemas_dir} STREQUAL "")
    # Set up the rule to generate binary schema (BFBS) files.
    set(binary_schema ${binary_schemas_dir}/${filename}.bfbs)
    add_custom_command(
      OUTPUT ${binary_schema}
      COMMAND ${FLATC} -b --schema
              -o ${binary_schemas_dir}
              ${include_params}
              ${schema}
      DEPENDS ${FLATC_TARGET} ${schema} ${additional_dependencies}
      WORKING_DIRECTORY "${working_dir}")
    list(APPEND all_generated_files ${binary_schema})
  endif()
  ...
endfunction()
```

The rule for generating BFBS files (such as Discovery.bfbs) is created only if the variable binary_schemas_dir is not empty. The condition essentially is 'if (NOT ${binary_schemas_dir} STREQUAL "")'

This is how it looks in schemas/CMakeLists.txt
```
build_flatbuffers("${FB_SCHEMAS}" ${CMAKE_CURRENT_SOURCE_DIR} ${FB_SCHEMA_TARGET_NAME} "" ${CMAKE_BINARY_DIR} "" "")
```

If it is not specified as the build directly (not build/schemas) then it'll throw the same error as if it's empty;

```
gmake[2]: *** No rule to make target 'Discovery.bfbs', needed by 'AccountClientStub.h'. Stop. 
gmake[1]: *** [CMakeFiles/Makefile2:1243: 
schemas/CMakeFiles/SPARK_RPC_GENERATE.dir/all] Error 2 
gmake: *** [Makefile:146: all] Error 2
```
