### PR TITLE
Be more inclusive for mac

### DIFF
--- a/src/libs/ports/include/ports/pcp/DatagramTransport.h
+++ b/src/libs/ports/include/ports/pcp/DatagramTransport.h
@@ -17,6 +17,7 @@
 #include <queue>
 #include <thread>
 #include <cstdint>
+#include <span>
 
 namespace ember::ports {
 

--- a/src/tools/dbcparser/Validator.h
+++ b/src/tools/dbcparser/Validator.h
@@ -21,6 +21,7 @@
 #include <regex>
 #include <utility>
 #include <cstddef>
+#include <algorithm>
 
 namespace ember::dbc {
 


### PR DESCRIPTION
mac needs more explicitly stated includes.

Without these you're getting:

```
[ 26%] Building CXX object src/libs/ports/CMakeFiles/ports.dir/src/pcp/Client.cpp.o
In file included from /Users/holsthein/Ember/src/libs/ports/src/pcp/Client.cpp:9:
In file included from /Users/holsthein/Ember/src/libs/ports/include/ports/pcp/Client.h:11:
/Users/holsthein/Ember/src/libs/ports/include/ports/pcp/DatagramTransport.h:29:44: error: no member named 'span' in namespace 'std'
   29 |         using OnReceive = std::function<void(std::span<std::uint8_t>, const ba::ip::udp::endpoint&)>;
      |                                              ~~~~~^
/Users/holsthein/Ember/src/libs/ports/include/ports/pcp/DatagramTransport.h:29:61: error: expected '(' for function-style cast or type construction
   29 |         using OnReceive = std::function<void(std::span<std::uint8_t>, const ba::ip::udp::endpoint&)>;
      |                                                        ~~~~~~~~~~~~^
/Users/holsthein/Ember/src/libs/ports/include/ports/pcp/DatagramTransport.h:29:62: error: expected expression
   29 |         using OnReceive = std::function<void(std::span<std::uint8_t>, const ba::ip::udp::endpoint&)>;
      |                                                                     ^
/Users/holsthein/Ember/src/libs/ports/include/ports/pcp/DatagramTransport.h:29:64: error: expected expression
   29 |         using OnReceive = std::function<void(std::span<std::uint8_t>, const ba::ip::udp::endpoint&)>;
      |                                                                       ^
/Users/holsthein/Ember/src/libs/ports/include/ports/pcp/DatagramTransport.h:34:2: error: unknown type name 'OnReceive'; did you mean 'OnResolve'?
   34 |         OnReceive rcb_;
      |         ^~~~~~~~~
      |         OnResolve
/Users/holsthein/Ember/src/libs/ports/include/ports/pcp/DatagramTransport.h:31:8: note: 'OnResolve' declared here
   31 |         using OnResolve = std::function<void(const boost::system::error_code&,
      |               ^
/Users/holsthein/Ember/src/libs/ports/include/ports/pcp/DatagramTransport.h:55:21: error: unknown type name 'OnReceive'; did you mean 'OnResolve'?
   55 |         void set_callbacks(OnReceive rcb, OnConnectionError ecb);
      |                            ^~~~~~~~~
      |                            OnResolve
/Users/holsthein/Ember/src/libs/ports/include/ports/pcp/DatagramTransport.h:31:8: note: 'OnResolve' declared here
   31 |         using OnResolve = std::function<void(const boost::system::error_code&,
      |               ^
/Users/holsthein/Ember/src/libs/ports/src/pcp/Client.cpp:33:3: error: no viable conversion from '(lambda at /Users/holsthein/Ember/src/libs/ports/src/pcp/Client.cpp:33:3)' to 'OnResolve' (aka 'function<void (const boost::system::error_code &, const basic_endpoint<udp> &)>')
   33 |                 [&](std::span<std::uint8_t> buffer, const bai::udp::endpoint& ep) {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   34 |                         boost::asio::dispatch(ctx_, boost::asio::bind_executor(strand_, [&, buffer = std::move(buffer), ep]() {
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   35 |                                 handle_message(buffer, ep);
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
   36 |                         }));
      |                         ~~~~
   37 |                 },
      |                 ~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/__functional/function.h:862:25: note: candidate constructor not viable: no known conversion from '(lambda at /Users/holsthein/Ember/src/libs/ports/src/pcp/Client.cpp:33:3)' to 'nullptr_t' (aka 'std::nullptr_t') for 1st argument
  862 |   _LIBCPP_HIDE_FROM_ABI function(nullptr_t) _NOEXCEPT {}
      |                         ^        ~~~~~~~~~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/__functional/function.h:863:25: note: candidate constructor not viable: no known conversion from '(lambda at /Users/holsthein/Ember/src/libs/ports/src/pcp/Client.cpp:33:3)' to 'const function<void (const error_code &, const basic_endpoint<udp> &)> &' for 1st argument
  863 |   _LIBCPP_HIDE_FROM_ABI function(const function&);
      |                         ^        ~~~~~~~~~~~~~~~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/__functional/function.h:864:25: note: candidate constructor not viable: no known conversion from '(lambda at /Users/holsthein/Ember/src/libs/ports/src/pcp/Client.cpp:33:3)' to 'function<void (const error_code &, const basic_endpoint<udp> &)> &&' for 1st argument
  864 |   _LIBCPP_HIDE_FROM_ABI function(function&&) _NOEXCEPT;
      |                         ^        ~~~~~~~~~~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/__functional/function.h:866:25: note: candidate template ignored: requirement '__callable<(lambda at /Users/holsthein/Ember/src/libs/ports/src/pcp/Client.cpp:33:3) &, false>::value' was not satisfied [with _Fp = (lambda at /Users/holsthein/Ember/src/libs/ports/src/pcp/Client.cpp:33:3)]
  866 |   _LIBCPP_HIDE_FROM_ABI function(_Fp);
      |                         ^
/Users/holsthein/Ember/src/libs/ports/include/ports/pcp/DatagramTransport.h:55:31: note: passing argument to parameter 'rcb' here
   55 |         void set_callbacks(OnReceive rcb, OnConnectionError ecb);
      |                                      ^
7 errors generated.
gmake[2]: *** [src/libs/ports/CMakeFiles/ports.dir/build.make:79: src/libs/ports/CMakeFiles/ports.dir/src/pcp/Client.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:2148: src/libs/ports/CMakeFiles/ports.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```

```
[ 33%] Building CXX object src/tools/dbcparser/CMakeFiles/dbc-parser.dir/Validator.cpp.o
/Users/holsthein/Ember/src/tools/dbcparser/Validator.cpp:88:18: error: no member named 'find' in namespace 'std::ranges'
   88 |         if(std::ranges::find(names_, def->name) == names_.end()) {
      |            ~~~~~~~~~~~~~^
/Users/holsthein/Ember/src/tools/dbcparser/Validator.cpp:104:20: error: no member named 'find' in namespace 'std::ranges'
  104 |                         if(std::ranges::find(sym_names, symbol->name) == sym_names.end()) {
      |                            ~~~~~~~~~~~~~^
/Users/holsthein/Ember/src/tools/dbcparser/Validator.cpp:114:20: error: no member named 'find' in namespace 'std::ranges'
  114 |                         if(std::ranges::find(sym_names, symbol.first) == sym_names.end()) {
      |                            ~~~~~~~~~~~~~^
/Users/holsthein/Ember/src/tools/dbcparser/Validator.cpp:174:18: error: no member named 'find_if' in namespace 'std::ranges'
  174 |         if(std::ranges::find_if(node->children,
      |            ~~~~~~~~~~~~~^
/Users/holsthein/Ember/src/tools/dbcparser/Validator.cpp:290:25: error: no member named 'find_if' in namespace 'std::ranges'
  290 |         auto it = std::ranges::find_if(node->children,
      |                   ~~~~~~~~~~~~~^
/Users/holsthein/Ember/src/tools/dbcparser/Validator.cpp:399:19: error: no member named 'find_if' in namespace 'std::ranges'
  399 |                 if(std::ranges::find_if(options,
      |                    ~~~~~~~~~~~~~^
6 errors generated.
gmake[2]: *** [src/tools/dbcparser/CMakeFiles/dbc-parser.dir/build.make:107: src/tools/dbcparser/CMakeFiles/dbc-parser.dir/Validator.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:2219: src/tools/dbcparser/CMakeFiles/dbc-parser.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```