### PR TITLE
vcpkg updates

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "d2b6159679a36b233b0c31bdf027a57c2bf480db",
+    "baseline": "8945a6d89ce4ae46de7dd2834ac31f33c98ad3ab",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,12 +2,20 @@
   "dependencies": [
     "boost-asio",
     "boost-headers",
+    "boost-interprocess",
     "boost-program-options",
     "boost-system",
+    "boost-uuid",
     "botan",
     "flatbuffers",
     "pcre",
-    "zlib"
+    "zlib",
+    {
+      "name": "mysql-connector-cpp",
+      "features": [
+        "jdbc"
+      ]
+    }
   ],
   "overrides": [
     {


### PR DESCRIPTION
Adds missing dependencies to vcpkg.json and updates the baseline hash for vcpkg-configuration

boost-uuid
```
[ 24%] Building CXX object src/libs/spark/CMakeFiles/spark.dir/src/Peers.cpp.o
In file included from /Users/holsthein/Ember/src/libs/spark/src/Peers.cpp:10:
In file included from /Users/holsthein/Ember/src/libs/spark/include/spark/RemotePeer.h:12:
In file included from /Users/holsthein/Ember/src/libs/spark/include/spark/Connection.h:12:
/Users/holsthein/Ember/src/libs/spark/include/spark/Common.h:14:10: fatal error: 'boost/uuid/uuid.hpp' file not found
   14 | #include <boost/uuid/uuid.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~~
1 error generated.
gmake[2]: *** [src/libs/spark/CMakeFiles/spark.dir/build.make:79: src/libs/spark/CMakeFiles/spark.dir/src/Peers.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:1950: src/libs/spark/CMakeFiles/spark.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```

boost-interprocess:
```
[ 36%] Building CXX object src/libs/dbcreader/CMakeFiles/dbcreader.dir/__/__/dbcreader/DiskLoader.cpp.o
/Users/holsthein/Ember/build/src/dbcreader/DiskLoader.cpp:21:10: fatal error: 'boost/interprocess/file_mapping.hpp' file not found
   21 | #include <boost/interprocess/file_mapping.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
gmake[2]: *** [src/libs/dbcreader/CMakeFiles/dbcreader.dir/build.make:173: src/libs/dbcreader/CMakeFiles/dbcreader.dir/__/__/dbcreader/DiskLoader.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:2048: src/libs/dbcreader/CMakeFiles/dbcreader.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```