### PR TITLE
More mac support

### DIFF
--- a/src/libs/stun/src/MessageBuilder.cpp
+++ b/src/libs/stun/src/MessageBuilder.cpp
@@ -118,7 +118,7 @@ void MessageBuilder::add_response_port(std::uint16_t port) {
 }
 
 void MessageBuilder::set_header_length(const std::uint16_t length) {
-	static_assert(stream_.can_write_seek());
+	assert(stream_.can_write_seek());
 	const auto pos = stream_.size();
 	stream_.write_seek(spark::io::StreamSeek::SK_BUFFER_ABSOLUTE, HEADER_LEN_OFFSET);
 	stream_ << len_be(length);

--- a/src/tools/dbcparser/Generator.cpp
+++ b/src/tools/dbcparser/Generator.cpp
@@ -62,7 +62,7 @@ std::optional<std::string> locate_type(const types::Struct& base, const std::str
 		return std::nullopt;
 	}
 
-	MUST_TAIL return locate_type(static_cast<types::Struct&>(*base.parent), type_name);
+	return locate_type(static_cast<types::Struct&>(*base.parent), type_name);
 }
 
 std::string parent_alias(const types::Definitions& defs, const std::string& parent) {


### PR DESCRIPTION
Remove static assertion:
```
[ 37%] Building CXX object src/libs/stun/CMakeFiles/stun.dir/src/MessageBuilder.cpp.o
/Users/holsthein/Ember/src/libs/stun/src/MessageBuilder.cpp:121:16: error: static assertion expression is not an integral constant expression
  121 |         static_assert(stream_.can_write_seek());
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~
/Users/holsthein/Ember/src/libs/stun/src/MessageBuilder.cpp:121:16: note: implicit use of 'this' pointer is only allowed within the evaluation of a call to a 'constexpr' member function
1 error generated.
gmake[2]: *** [src/libs/stun/CMakeFiles/stun.dir/build.make:149: src/libs/stun/CMakeFiles/stun.dir/src/MessageBuilder.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:2115: src/libs/stun/CMakeFiles/stun.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```

Remove MUST_TAIL:
```

[ 32%] Building CXX object src/tools/dbcparser/CMakeFiles/dbc-parser.dir/Generator.cpp.o
/Users/holsthein/Ember/src/tools/dbcparser/Generator.cpp:65:12: error: tail call requires that the return value, all parameters, and any temporaries created by the expression are trivially destructible
   65 |         MUST_TAIL return locate_type(static_cast<types::Struct&>(*base.parent), type_name);
      |                   ^
1 error generated.
gmake[2]: *** [src/tools/dbcparser/CMakeFiles/dbc-parser.dir/build.make:121: src/tools/dbcparser/CMakeFiles/dbc-parser.dir/Generator.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:2219: src/tools/dbcparser/CMakeFiles/dbc-parser.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```
