### PR TITLE
Update Spinlock.h to support arm_osx yield functionality

### DIFF
--- a/src/libs/shared/shared/threading/Spinlock.h
+++ b/src/libs/shared/shared/threading/Spinlock.h
@@ -10,7 +10,9 @@
 
 #if defined(__x86_64__) || defined(_M_X64) || defined(i386) || defined(__i386__) || defined(__i386) || defined(_M_IX86)
 #define ember_x86_or_x64
-#elif defined(__arm__) || defined(_M_ARM) || defined(_M_ARM64) || defined(_M_ARM64EC) || defined(__aarch64__) || defined(_M_ARM64)
+#elif defined(__APPLE__) && defined(__aarch64__)
+#define ember_arm_osx
+#elif defined(__arm__) || defined(_M_ARM) || defined(_M_ARM64) || defined(_M_ARM64EC) || defined(__aarch64__)
 #define ember_arm
 #endif
 
@@ -51,6 +53,8 @@ public:
 				_mm_pause();
 #elif defined(ember_arm)
 				__yield();
+#elif defined(ember_arm_osx)
+				__builtin_arm_yield();
 #endif
 			}
 		}


### PR DESCRIPTION
Remove duplicate entry: defined(_M_ARM64) (3rd and 6th position)

Apple silicon cannot use __yield but can use __builtin_arm_yield

```
/Users/holsthein/Ember/src/libs/shared/shared/threading/Spinlock.h:53:5: error: use of undeclared identifier '__yield'
   53 |                                 __yield();
      |                                 ^
```
