### PR TITLE
macOS: Update MemoryArchive.cpp

### DIFF
--- a/src/libs/mpq/src/base/MemoryArchive.cpp
+++ b/src/libs/mpq/src/base/MemoryArchive.cpp
@@ -18,6 +18,7 @@
 #include <boost/container/small_vector.hpp>
 #include <bit>
 #include <iterator>
+#include <sstream>
 
 namespace ember::mpq {
 


### PR DESCRIPTION
mac needs a little help finding sstream for stringstream

Fails without it like so:

```
[ 59%] Building CXX object src/libs/mpq/CMakeFiles/mpq.dir/src/base/MemoryArchive.cpp.o
/Users/holsthein/Ember/src/libs/mpq/src/base/MemoryArchive.cpp:51:20: error: implicit instantiation of undefined template 'std::basic_stringstream<char>'
   51 |         std::stringstream stream;
      |                           ^
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/__fwd/sstream.h:30:28: note: template is declared here
   30 | class _LIBCPP_TEMPLATE_VIS basic_stringstream;
      |                            ^
1 error generated.
gmake[2]: *** [src/libs/mpq/CMakeFiles/mpq.dir/build.make:79: src/libs/mpq/CMakeFiles/mpq.dir/src/base/MemoryArchive.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:2186: src/libs/mpq/CMakeFiles/mpq.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```