### PR TITLE
macOS support: Update Realmlist

### DIFF
--- a/src/login/RealmList.cpp
+++ b/src/login/RealmList.cpp
@@ -23,7 +23,7 @@ void RealmList::add_realm(std::span<const Realm> realms) {
 	// ensure consistency if we add from multiple workers (not a thread safety issue)
 	std::lock_guard guard(lock_);
 
-	auto realm_map = realms_.load();
+	auto realm_map = std::atomic_load(&realms_);
 	auto copy = std::make_shared<RealmMap>(*realm_map);
 	
 	for(const auto& realm : realms) {
@@ -37,7 +37,7 @@ void RealmList::add_realm(Realm realm) {
 	// ensure consistency if we add from multiple workers (not a thread safety issue)
 	std::lock_guard guard(lock_);
 
-	auto realm_map = realms_.load();
+	auto realm_map = std::atomic_load(&realms_);
 	auto copy = std::make_shared<RealmMap>(*realm_map);
 	copy->insert_or_assign(realm.id, std::move(realm));
 
@@ -45,7 +45,7 @@ void RealmList::add_realm(Realm realm) {
 }
 
 std::optional<Realm> RealmList::get_realm(const std::uint32_t id) const {
-	auto realms = realms_.load();
+	auto realms = std::atomic_load(&realms_);
 
 	if(auto it = realms->find(id); it != realms->end()) {
 		return it->second;
@@ -55,7 +55,7 @@ std::optional<Realm> RealmList::get_realm(const std::uint32_t id) const {
 }
 
 auto RealmList::realms() const -> std::shared_ptr<const RealmMap> {
-	auto realms = realms_.load();
+	auto realms = std::atomic_load(&realms_);
 	return realms;
 }
 

--- a/src/login/RealmList.h
+++ b/src/login/RealmList.h
@@ -22,7 +22,7 @@ namespace ember {
 using RealmMap = boost::unordered_flat_map<std::uint32_t, Realm>;
 
 class RealmList final {
-	std::atomic<std::shared_ptr<const RealmMap>> realms_;
+	std::shared_ptr<const RealmMap> realms_;
 	mutable std::mutex lock_;
 
 public:


### PR DESCRIPTION
Atomically load shared_ptr instead of declaring atomically.

This is to satisfy clang/libc++ Atomic declaration of shared pointers is not supported on clang/libc++ - atomic loading of shared pointers is however.

```
 /opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/__atomic/support.h:116:17: error: static assertion failed due to requirement 'is_trivially_copyable<std::shared_ptr<const boost::unordered::unordered_flat_map<unsigned int, ember::Realm, boost::hash<unsigned int>, std::equal_to<unsigned int>, std::allocator<std::pair<const unsigned int, ember::Realm>>>>>::value': std::atomic<T> requires that 'T' be a trivially copyable type
  116 |   static_assert(is_trivially_copyable<_Tp>::value, "std::atomic<T> requires that 'T' be a trivially copyable type");
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/__atomic/atomic.h:41:34: note: in instantiation of template class 'std::__cxx_atomic_impl<std::shared_ptr<const boost::unordered::unordered_flat_map<unsigned int, ember::Realm>>>' requested here
   41 |   mutable __cxx_atomic_impl<_Tp> __a_;
      |                                  ^
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/__atomic/atomic.h:230:24: note: in instantiation of template class 'std::__atomic_base<std::shared_ptr<const boost::unordered::unordered_flat_map<unsigned int, ember::Realm>>>' requested here
  230 | struct atomic : public __atomic_base<_Tp> {
      |                        ^
/Users/holsthein/Ember/src/login/RealmList.h:25:47: note: in instantiation of template class 'std::atomic<std::shared_ptr<const boost::unordered::unordered_flat_map<unsigned int, ember::Realm>>>' requested here
   25 |         std::atomic<std::shared_ptr<const RealmMap>> realms_;
      |                                                      ^
2 warnings and 2 errors generated.
gmake[2]: *** [src/login/CMakeFiles/liblogin.dir/build.make:79: src/login/CMakeFiles/liblogin.dir/LoginHandler.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:1329: src/login/CMakeFiles/liblogin.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2

```
