### PR TITLE
Update MonitorCallbacks.h

### DIFF
--- a/src/social/MonitorCallbacks.h
+++ b/src/social/MonitorCallbacks.h
@@ -35,7 +35,7 @@ void install_pool_monitor(Monitor& monitor, const T& pool, log::Logger& logger) 
 
 	monitor.add_source(source, Monitor::Severity::ERROR,
 		std::bind(monitor_log_callback, std::placeholders::_1, std::placeholders::_2,
-		          std::placeholders::_3, logger)
+		          std::placeholders::_3, std::ref(logger))
 	);
 }
 


### PR DESCRIPTION
Satisfy clang/libc++ ...

Wants a ref wrapper when passing a value in a std::bind

```

In file included from /opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/functional:539:
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/__functional/bind.h:217:39: error: no matching constructor for initialization of '_Td' (aka 'tuple<std::placeholders::__ph<1>, std::placeholders::__ph<2>, std::placeholders::__ph<3>, ember::log::Logger>')
  217 |       : __f_(std::forward<_Gp>(__f)), __bound_args_(std::forward<_BA>(__bound_args)...) {}
      |                                       ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/__functional/bind.h:279:10: note: in instantiation of function template specialization 'std::__bind<void (&)(const ember::Monitor::Source &, ember::Monitor::Severity, long, ember::log::Logger &), const std::placeholders::__ph<1> &, const std::placeholders::__ph<2> &, const std::placeholders::__ph<3> &, ember::log::Logger &>::__bind<void (&)(const ember::Monitor::Source &, ember::Monitor::Severity, long, ember::log::Logger &), const std::placeholders::__ph<1> &, const std::placeholders::__ph<2> &, const std::placeholders::__ph<3> &, ember::log::Logger &, 0>' requested here
  279 |   return type(std::forward<_Fp>(__f), std::forward<_BoundArgs>(__bound_args)...);
      |          ^
/Users/holsthein/Ember/src/social/MonitorCallbacks.h:37:8: note: in instantiation of function template specialization 'std::bind<void (&)(const ember::Monitor::Source &, ember::Monitor::Severity, long, ember::log::Logger &), const std::placeholders::__ph<1> &, const std::placeholders::__ph<2> &, const std::placeholders::__ph<3> &, ember::log::Logger &>' requested here
   37 |                 std::bind(monitor_log_callback, std::placeholders::_1, std::placeholders::_2,
      |                      ^
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/tuple:586:7: note: candidate template ignored: requirement 'integral_constant<bool, false>::value' was not satisfied [with _And = _And]
  586 |       tuple(const _Tp&... __t) noexcept(_And<is_nothrow_copy_constructible<_Tp>...>::value)
      |       ^
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/tuple:635:7: note: candidate template ignored: requirement 'integral_constant<bool, false>::value' was not satisfied [with _Alloc = std::placeholders::__ph<2>, _Up = <const std::placeholders::__ph<3> &, ember::log::Logger &>]
  635 |       tuple(allocator_arg_t, const _Alloc& __a, _Up&&... __u)
      |       ^
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/tuple:651:55: note: candidate constructor template not viable: requires 3 arguments, but 4 were provided
  651 |   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 tuple(allocator_arg_t, const _Alloc& __alloc, const tuple& __t)
      |                                                       ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/tuple:657:55: note: candidate constructor template not viable: requires 3 arguments, but 4 were provided
  657 |   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 tuple(allocator_arg_t, const _Alloc& __alloc, tuple&& __t)
      |                                                       ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/tuple:698:7: note: candidate constructor template not viable: requires 3 arguments, but 4 were provided
  698 |       tuple(allocator_arg_t, const _Alloc& __a, const tuple<_Up...>& __t)
      |       ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/tuple:710:7: note: candidate constructor template not viable: requires 3 arguments, but 4 were provided
  710 |       tuple(allocator_arg_t, const _Alloc& __alloc, tuple<_Up...>& __t)
      |       ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/tuple:724:7: note: candidate constructor template not viable: requires 3 arguments, but 4 were provided
  724 |       tuple(allocator_arg_t, const _Alloc& __a, tuple<_Up...>&& __t)
      |       ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/tuple:739:7: note: candidate constructor template not viable: requires 3 arguments, but 4 were provided
  739 |       tuple(allocator_arg_t, const _Alloc& __alloc, const tuple<_Up...>&& __t)
      |       ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/tuple:784:7: note: candidate constructor template not viable: requires 3 arguments, but 4 were provided
  784 |       tuple(allocator_arg_t, const _Alloc& __a, const pair<_Up1, _Up2>& __p)
      |       ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/tuple:800:7: note: candidate constructor template not viable: requires 3 arguments, but 4 were provided
  800 |       tuple(allocator_arg_t, const _Alloc& __alloc, pair<_U1, _U2>& __p)
      |       ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/tuple:822:7: note: candidate constructor template not viable: requires 3 arguments, but 4 were provided
  822 |       tuple(allocator_arg_t, const _Alloc& __a, pair<_Up1, _Up2>&& __p)
      |       ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/tuple:838:7: note: candidate constructor template not viable: requires 3 arguments, but 4 were provided
  838 |       tuple(allocator_arg_t, const _Alloc& __alloc, const pair<_U1, _U2>&& __p)
      |       ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/tuple:573:7: note: candidate constructor template not viable: requires 2 arguments, but 4 were provided
  573 |       tuple(allocator_arg_t, _Alloc const& __a)
      |       ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/tuple:598:7: note: candidate constructor template not viable: requires 6 arguments, but 4 were provided
  598 |       tuple(allocator_arg_t, const _Alloc& __a, const _Tp&... __t)
      |       ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/tuple:623:7: note: candidate template ignored: requirement 'integral_constant<bool, false>::value' was not satisfied [with _Up = <const std::placeholders::__ph<1> &, const std::placeholders::__ph<2> &, const std::placeholders::__ph<3> &, ember::log::Logger &>]
  623 |       tuple(_Up&&... __u) noexcept(_And<is_nothrow_constructible<_Tp, _Up>...>::value)
      |       ^
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/tuple:645:3: note: candidate constructor not viable: requires 1 argument, but 4 were provided
  645 |   tuple(const tuple&) = default;
      |   ^     ~~~~~~~~~~~~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/tuple:690:7: note: candidate constructor template not viable: requires single argument '__t', but 4 arguments were provided
  690 |       tuple(const tuple<_Up...>& __t) noexcept(_And<is_nothrow_constructible<_Tp, const _Up&>...>::value)
      |       ^     ~~~~~~~~~~~~~~~~~~~~~~~~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/tuple:705:95: note: candidate constructor template not viable: requires single argument '__t', but 4 arguments were provided
  705 |   _LIBCPP_HIDE_FROM_ABI constexpr explicit(!_Lazy<_And, is_convertible<_Up&, _Tp>...>::value) tuple(tuple<_Up...>& __t)
      |                                                                                               ^     ~~~~~~~~~~~~~~~~~~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/tuple:717:7: note: candidate constructor template not viable: requires single argument '__t', but 4 arguments were provided
  717 |       tuple(tuple<_Up...>&& __t) noexcept(_And<is_nothrow_constructible<_Tp, _Up>...>::value)
      |       ^     ~~~~~~~~~~~~~~~~~~~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/tuple:732:7: note: candidate constructor template not viable: requires single argument '__t', but 4 arguments were provided
  732 |       tuple(const tuple<_Up...>&& __t)
      |       ^     ~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/tuple:774:7: note: candidate constructor template not viable: requires single argument '__p', but 4 arguments were provided
  774 |       tuple(const pair<_Up1, _Up2>& __p) noexcept(_NothrowConstructibleFromPair<const pair<_Up1, _Up2>&>::value)
      |       ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/tuple:792:7: note: candidate constructor template not viable: requires single argument '__p', but 4 arguments were provided
  792 |       tuple(pair<_U1, _U2>& __p)
      |       ^     ~~~~~~~~~~~~~~~~~~~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/tuple:812:7: note: candidate constructor template not viable: requires single argument '__p', but 4 arguments were provided
  812 |       tuple(pair<_Up1, _Up2>&& __p) noexcept(_NothrowConstructibleFromPair<pair<_Up1, _Up2>&&>::value)
      |       ^     ~~~~~~~~~~~~~~~~~~~~~~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/tuple:830:7: note: candidate constructor template not viable: requires single argument '__p', but 4 arguments were provided
  830 |       tuple(const pair<_U1, _U2>&& __p)
      |       ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/homebrew/Cellar/llvm/20.1.3/bin/../include/c++/v1/tuple:566:7: note: candidate constructor template not viable: requires 0 arguments, but 4 were provided
  566 |       tuple() noexcept(_And<is_nothrow_default_constructible<_Tp>...>::value) {}
      |       ^
1 error generated.
gmake[2]: *** [src/social/CMakeFiles/libsocial.dir/build.make:79: src/social/CMakeFiles/libsocial.dir/MonitorCallbacks.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:1400: src/social/CMakeFiles/libsocial.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```
