### PR TITLE
[RFC]: Provide __1 namespace for armc_osx compatibility

### DIFF
--- a/src/libs/mpq/src/Compression.cpp
+++ b/src/libs/mpq/src/Compression.cpp
@@ -232,3 +232,16 @@ std::expected<std::size_t, DecompressionError> decompress(std::span<const std::b
 }
 
 } // mpq, ember
+
+#if defined(__APPLE__)
+namespace std {
+	inline namespace __1 {
+	  // Provide the out-of-line definition for the already explicitly specialized
+	  // member function for bad_expected_access<void>
+	  const char* bad_expected_access<void>::what() const noexcept {
+		return "bad expected access";
+	  	}
+	} // inline namespace __1
+} // namespace std
+
+#endif  // __APPLE__

--- a/src/mdns/Server.cpp
+++ b/src/mdns/Server.cpp
@@ -113,3 +113,16 @@ void Server::shutdown() {
 }
 
 } // dns, ember
+
+#if defined(__APPLE__)
+namespace std {
+	inline namespace __1 {
+	  // Provide the out-of-line definition for the already explicitly specialized
+	  // member function for bad_expected_access<void>
+	  const char* bad_expected_access<void>::what() const noexcept {
+		return "bad expected access";
+	  	}
+	} // inline namespace __1
+} // namespace std
+
+#endif  // __APPLE__


### PR DESCRIPTION
arm_osx does not have any __1 handling.
This is not meant as a proper long term solution but rather to showcase a workaround.

Current issue:

```
Undefined symbols for architecture arm64:
  "std::__1::bad_expected_access<void>::what() const", referenced from:
      vtable for std::__1::bad_expected_access<int> in mpq.a[6](Compression.cpp.o)
  "typeinfo for std::__1::bad_expected_access<void>", referenced from:
      typeinfo for std::__1::bad_expected_access<int> in mpq.a[6](Compression.cpp.o)
  "vtable for std::__1::bad_expected_access<void>", referenced from:
      std::__1::bad_expected_access<void>::bad_expected_access[abi:ne200100]() in mpq.a[6](Compression.cpp.o)
   NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
ld: symbol(s) not found for architecture arm64
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
gmake[2]: *** [tests/CMakeFiles/unit_tests.dir/build.make:546: tests/unit_tests] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:1291: tests/CMakeFiles/unit_tests.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```

```

Undefined symbols for architecture arm64:
  "std::__1::bad_expected_access<void>::what() const", referenced from:
      vtable for std::__1::bad_expected_access<ember::dns::parser::Result> in libmdns.a[4](Server.cpp.o)
  "typeinfo for std::__1::bad_expected_access<void>", referenced from:
      typeinfo for std::__1::bad_expected_access<ember::dns::parser::Result> in libmdns.a[4](Server.cpp.o)
  "vtable for std::__1::bad_expected_access<void>", referenced from:
      std::__1::bad_expected_access<void>::bad_expected_access[abi:ne200100]() in libmdns.a[4](Server.cpp.o)
   NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
ld: symbol(s) not found for architecture arm64
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
gmake[2]: *** [src/mdns/CMakeFiles/mdns.dir/build.make:114: src/mdns/mdns] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:1715: src/mdns/CMakeFiles/mdns.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```
