### PR TITLE
Update BinaryStream

### DIFF
--- a/tests/BinaryStream.cpp
+++ b/tests/BinaryStream.cpp
@@ -141,7 +141,7 @@ TEST(BinaryStream, ReadWriteVector) {
 	std::srand(seed);
 
 	std::vector<int> in(std::rand() % 200);
-	std::ranges::iota(in, std::rand() % 100);
+	std::iota(in.begin(), in.end(), std::rand() % 100);
 	std::ranges::shuffle(in, std::default_random_engine(seed));
 
 	stream.put(in.begin(), in.end());

--- a/tests/BinaryStreamPMR.cpp
+++ b/tests/BinaryStreamPMR.cpp
@@ -135,7 +135,7 @@ TEST(BinaryStreamPMR, ReadWriteVector) {
 	std::srand(seed);
 
 	std::vector<int> in(std::rand() % 200);
-	std::ranges::iota(in, std::rand() % 100);
+	std::iota(in.begin(), in.end(), std::rand() % 100);
 	std::ranges::shuffle(in, std::default_random_engine(seed));
 
 	stream.put(in.begin(), in.end());


### PR DESCRIPTION
Make libc++ happy... It doesn't agree with iota residing inside ranges.

```

[ 64%] Building CXX object tests/CMakeFiles/unit_tests.dir/BinaryStreamPMR.cpp.o
/Users/holsthein/Ember/tests/BinaryStreamPMR.cpp:138:15: error: no member named 'iota' in namespace 'std::ranges'
  138 |         std::ranges::iota(in, std::rand() % 100);
      |         ~~~~~~~~~~~~~^
1 error generated.
gmake[2]: *** [tests/CMakeFiles/unit_tests.dir/build.make:121: tests/CMakeFiles/unit_tests.dir/BinaryStreamPMR.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:1291: tests/CMakeFiles/unit_tests.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```
