### PR TITLE
Replace TARGET_OS_MAC with __APPLE__

### DIFF
--- a/src/libs/shared/shared/threading/Utility.cpp
+++ b/src/libs/shared/shared/threading/Utility.cpp
@@ -17,7 +17,7 @@
 #ifdef _WIN32
 #include <Windows.h>
 #include <cwchar>
-#elif defined TARGET_OS_MAC
+#elif defined __APPLE__
 #include <pthread.h>
 #elif defined __linux__ || defined __unix__
 #include <sched.h>
@@ -39,7 +39,7 @@ void set_affinity(auto thread, unsigned int core) {
 	if(SetThreadAffinityMask(thread, 1u << core) == 0) {
 		throw std::runtime_error("Unable to set thread affinity, error code " + std::to_string(GetLastError()));
 	}
-#elif defined TARGET_OS_MAC
+#elif defined __APPLE__
 	// todo, no support for pthread_setaffinity_np - implement when I'm in a position to test it
 #elif defined __linux__ || defined __unix__
 	cpu_set_t mask;
@@ -91,7 +91,7 @@ Result set_name([[maybe_unused]] auto& handle, const char* name) {
 
 	FreeLibrary(lib);
 
-#elif defined TARGET_OS_MAC
+#elif defined __APPLE__
 	auto ret = pthread_setname_np(name);
 
 	if(ret) {
@@ -109,7 +109,7 @@ Result set_name([[maybe_unused]] auto& handle, const char* name) {
 }
 
 Result set_name(std::jthread& thread, const char* name) {
-#ifndef TARGET_OS_MAC
+#ifndef __APPLE__
 	const auto handle = thread.native_handle();
 	return set_name(handle, name);
 #else
@@ -119,7 +119,7 @@ Result set_name(std::jthread& thread, const char* name) {
 }
 
 Result set_name(std::thread& thread, const char* name) {
-#ifndef TARGET_OS_MAC
+#ifndef __APPLE__
 	const auto handle = thread.native_handle();
 	return set_name(handle, name);
 #else
@@ -132,7 +132,7 @@ Result set_name(const char* name) {
 #ifdef _WIN32
 	auto handle = GetCurrentThread();
 	return set_name(handle, name);
-#elif defined __linux__ || defined __unix__ || defined TARGET_OS_MAC
+#elif defined __linux__ || defined __unix__ || defined __APPLE__
 	auto handle = pthread_self();
 	return set_name(handle, name);
 #else
@@ -164,7 +164,7 @@ std::expected<std::wstring, Result> get_name(auto& thread) {
 	}
 
 	return std::wstring(buffer.data(), buffer.data() + wcslen(buffer.data()));
-#elif defined __linux__ || defined __unix__ || defined TARGET_OS_MAC
+#elif defined __linux__ || defined __unix__ || defined __APPLE__
 	std::array<char, BUFFER_LEN> buffer{};
 	auto res = pthread_getname_np(thread, buffer.data(), buffer.size());
 	
@@ -192,7 +192,7 @@ std::expected<std::wstring, Result> get_name() {
 #ifdef _WIN32
 	auto handle = GetCurrentThread();
 	return get_name(handle);
-#elif defined __linux__ || defined __unix__ || TARGET_OS_MAC
+#elif defined __linux__ || defined __unix__ || __APPLE__
 	auto handle = pthread_self();
 	return get_name(handle);
 #else

--- a/src/libs/shared/shared/utility/Utility.cpp
+++ b/src/libs/shared/shared/utility/Utility.cpp
@@ -11,13 +11,13 @@
 
 #ifdef _WIN32
     #include <Windows.h>
-#elif defined __linux__ || defined __unix__ || defined TARGET_OS_MAC
+#elif defined __linux__ || defined __unix__ || defined __APPLE__
 	#include <sys/resource.h>
 	#include <iostream>
 #endif
 
 // signal stuff
-#if defined _WIN32 || defined TARGET_OS_MAC
+#if defined _WIN32 || defined __APPLE__
 	#include <signal.h>
 #elif defined __linux__ || defined __unix__
 	#include <format>
@@ -27,7 +27,7 @@
 // page locking stuff
 #if defined _WIN32
 	#include <memoryapi.h>
-#elif defined __linux__ || defined __unix__  || defined TARGET_OS_MAC
+#elif defined __linux__ || defined __unix__  || defined __APPLE__
 	#include <sys/mman.h>
 #endif
 
@@ -69,7 +69,7 @@ void set_window_title(cstring_view title) {
 }
 
 int max_sockets() {
-#if defined __linux__ || defined __unix__ || defined TARGET_OS_MAC
+#if defined __linux__ || defined __unix__ || defined __APPLE__
 	rlimit limit{};
 	const int res = getrlimit(RLIMIT_NOFILE, &limit);
 	
@@ -102,7 +102,7 @@ case x: \
 	return #x;
 
 std::string sig_str(const int signal) {
-#if defined _WIN32 || defined TARGET_OS_MAC
+#if defined _WIN32 || defined __APPLE__
 	switch(signal) {
 		STRINGIZE_CASE(SIGINT)
 		STRINGIZE_CASE(SIGILL)
@@ -113,7 +113,7 @@ std::string sig_str(const int signal) {
 #ifdef  _WIN32
 		STRINGIZE_CASE(SIGBREAK)
 		STRINGIZE_CASE(SIGABRT)
-#elif defined TARGET_OS_MAC
+#elif defined __APPLE__
 		STRINGIZE_CASE(SIGHUP)
 		STRINGIZE_CASE(SIGQUIT)
 		STRINGIZE_CASE(SIGTRAP)
@@ -141,7 +141,7 @@ std::string sig_str(const int signal) {
 		STRINGIZE_CASE(SIGUSR1)
 		STRINGIZE_CASE(SIGUSR2)
 #endif
-#if defined _WIN32 || defined TARGET_OS_MAC
+#if defined _WIN32 || defined __APPLE__
 		default:
 			return "<unknown>";
 	}
@@ -161,7 +161,7 @@ std::string sig_str(const int signal) {
 bool page_lock(void* address, std::size_t length) {
 #if defined _WIN32
 	return VirtualLock(address, length) != 0;
-#elif defined __linux__ || defined __unix__|| defined TARGET_OS_MAC
+#elif defined __linux__ || defined __unix__|| defined __APPLE__
 	return mlock(address, length) == 0;
 #else
 	#pragma message WARN("Implement page_lock for this platform, thanks");
@@ -172,7 +172,7 @@ bool page_lock(void* address, std::size_t length) {
 bool page_unlock(void* address, std::size_t length) {
 #if defined _WIN32
 	return VirtualUnlock(address, length) != 0;
-#elif defined __linux__ || defined __unix__|| defined TARGET_OS_MAC
+#elif defined __linux__ || defined __unix__|| defined __APPLE__
 	return munlock(address, length) == 0;
 #else
 	#pragma message WARN("Implement page_unlock for this platform, thanks");


### PR DESCRIPTION
TARGET_OS_MAC is not part of the standard definitions - https://sourceforge.net/p/predef/wiki/OperatingSystems/

Satisfy GCC/libstdc++

`__APPLE__` is the proper define

```

/Users/holsthein/Ember/src/libs/shared/shared/utility/Utility.cpp:157:76: note: '#pragma message: WARNING: Implement sig_str for this platform, thanks'
/Users/holsthein/Ember/src/libs/shared/shared/utility/Utility.cpp:159:1: warning: no return statement in function returning non-void [-Wreturn-type]
  159 | }
```

Tail end of that function:

```
#if defined _WIN32 || defined TARGET_OS_MAC
        default:
            return "<unknown>";
    }
#elif defined __linux__ || defined __unix__
    auto res = sigabbrev_np(signal);

    if(res) {
        return std::format("SIG{}", res);
    } else {
        return "<unknown>";
    }
#else
    #pragma message WARN("Implement sig_str for this platform, thanks");
#endif
}
```