### PR TITLE
Update FindMySQLConnectorCPP.cmake

### DIFF
--- a/cmake/FindMySQLConnectorCPP.cmake
+++ b/cmake/FindMySQLConnectorCPP.cmake
@@ -3,29 +3,46 @@
 
 include(FindPackageHandleStandardArgs)
 
+set(MYSQLCCPP_ROOT_HINTS
+    include/mysql_connection.h            # Docker
+    include/jdbc/mysql_connection.h)      # vcpkg
+set(MYSQLCCPP_INCLUDE_PATH
+    include                               # Docker
+    include/jdbc)                         # vcpkg
+
+set(MYSQLCCPP_LIBRARY_NAMES
+    mysqlcppconn                          # Docker
+    libmysqlcppconn-static.a)             # vcpkg
 set(_MYSQLCCPP_POSSIBLE_LIB_SUFFIXES lib)
 
+set(MYSQLCCPP_LIBRARYD_NAMES
+    mysqlcppconnd                         # Docker
+    libmysqlcppconn-static.a)             # vcpkg
+set(_MYSQLCCPP_POSSIBLE_LIBD_SUFFIXES
+    debug/lib                             # vcpkg
+    lib)                                  # Docker
+
 find_path(MYSQLCCPP_ROOT_DIR
-          NAMES include/mysql_connection.h
+          NAMES ${MYSQLCCPP_ROOT_HINTS}
           PATHS ENV MYSQLCCPPROOT
           DOC "MySQL Connector/C++ root directory")
 
 find_path(MYSQLCCPP_INCLUDE_DIR
           NAMES mysql_connection.h
           HINTS ${MYSQLCCPP_ROOT_DIR}
-          PATH_SUFFIXES include
+          PATH_SUFFIXES ${MYSQLCCPP_INCLUDE_PATH}
           DOC "MySQL Connector/C++ include directory")
 
 find_library(MYSQLCCPP_LIBRARY_RELEASE
-             NAMES mysqlcppconn
+             NAMES ${MYSQLCCPP_LIBRARY_NAMES}
              HINTS ${MYSQLCCPP_ROOT_DIR}
              PATH_SUFFIXES ${_MYSQLCCPP_POSSIBLE_LIB_SUFFIXES}
              DOC "MySQL Connector/C++ release library")
 
 find_library(MYSQLCCPP_LIBRARY_DEBUG
-             NAMES mysqlcppconnd
+             NAMES ${MYSQLCCPP_LIBRARYD_NAMES}
              HINTS ${MYSQLCCPP_ROOT_DIR}
-             PATH_SUFFIXES ${_MYSQLCCPP_POSSIBLE_LIB_SUFFIXES}
+             PATH_SUFFIXES ${_MYSQLCCPP_POSSIBLE_LIBD_SUFFIXES}
              DOC "MySQL Connector/C++ debug library")
 
 if(MYSQLCCPP_LIBRARY_DEBUG AND MYSQLCCPP_LIBRARY_RELEASE)


### PR DESCRIPTION
Accommodate vcpkg folder structure and library naming scheme when searching for mysql-connector-c++

<img width="849" alt="Screenshot 2025-04-22 at 04 07 21" src="https://github.com/user-attachments/assets/b27203db-94c2-4da9-8ecb-ef78ef4adbb0" />

<img width="848" alt="Screenshot 2025-04-22 at 04 08 45" src="https://github.com/user-attachments/assets/53f016c8-11db-4ea3-9fe3-fac7418a533c" />
