### PR TITLE
ignore vcpkg_installed

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 /build
+/vcpkg_installed
 Dockerfile
 docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,9 @@ App_Data/*.ldf
 *.iml
 *.iws
 
+# vcpkg
+vcpkg_installed/
+
 # =========================
 # Windows detritus
 # =========================


### PR DESCRIPTION
vcpkg will populate a folder inside the ember source dir when running 'vcpkg install' from within the source which is the expected way of running 'vcpkg install'

<img width="245" alt="Screenshot 2025-04-23 at 22 53 51" src="https://github.com/user-attachments/assets/186e143f-1658-4bae-aeed-a6e804c98f90" />
