### PR TITLE
Missing include

### DIFF
--- a/tests/BinaryStreamPMR.cpp
+++ b/tests/BinaryStreamPMR.cpp
@@ -9,6 +9,7 @@
 #include <spark/buffers/pmr/BinaryStream.h>
 #include <spark/buffers/pmr/BufferAdaptor.h>
 #include <spark/buffers/DynamicBuffer.h>
+#include <shared/utility/polyfill/ranged_iota>
 #include <gtest/gtest.h>
 #include <gsl/narrow>
 #include <algorithm>


### PR DESCRIPTION
missing this include for the libc++ solution, otherwise it'll throw a fit about not knowing ranges::iota


<img width="935" alt="Screenshot 2025-04-26 at 02 12 59" src="https://github.com/user-attachments/assets/b7f306c2-5c32-45a4-b7f6-a477b1fb7d94" />
