### PR TITLE
[WIP]: Threading (macOS): implement set_name

### DIFF
--- a/src/libs/shared/shared/threading/Utility.cpp
+++ b/src/libs/shared/shared/threading/Utility.cpp
@@ -14,11 +14,19 @@
 #include <string>
 #include <cstring>
 
+#if defined __APPLE__
+	#include <TargetConditionals.h>
+#endif
+
 #ifdef _WIN32
 #include <Windows.h>
 #include <cwchar>
 #elif defined TARGET_OS_MAC
 #include <pthread.h>
+#include <mach/mach.h>
+#include <mach/thread_policy.h>
+#include <signal.h>
+#include <atomic>
 #elif defined __linux__ || defined __unix__
 #include <sched.h>
 #include <pthread.h>
@@ -92,11 +100,36 @@ Result set_name([[maybe_unused]] auto& handle, const char* name) {
 	FreeLibrary(lib);
 
 #elif defined TARGET_OS_MAC
-	auto ret = pthread_setname_np(name);
+	static std::atomic<const char*> desiredThreadName{name};
+	static std::atomic<kern_return_t> ret{KERN_FAILURE};
+	static std::atomic<bool> busy{true};
 
-	if(ret) {
-		throw std::runtime_error("Unable to set thread name, error code" + std::to_string(ret));
+	// Define the signal handler
+	const auto threadNameHandler = +[](int /*signum*/) -> void {
+		const char* name = desiredThreadName.load(std::memory_order_acquire);
+		if (name != nullptr) {
+			ret.store(pthread_setname_np(name), std::memory_order_release);
+		}
+		busy.store(false, std::memory_order_release);
+	};
+
+	// Install the signal handler once for the process.
+	static std::atomic_flag handlerInstalled = ATOMIC_FLAG_INIT;
+	if (!handlerInstalled.test_and_set(std::memory_order_acquire)) {
+		signal(SIGUSR1, threadNameHandler);
 	}
+
+	// Send SIGUSR1 to the target thread so it runs the signal handler.
+	if (pthread_kill(handle, SIGUSR1) != 0) {
+		throw std::runtime_error("Unable to send signal handler to thread, error code " + std::to_string(ret));
+	}
+
+	while (busy == true) {std::this_thread::yield();}
+
+    if (ret.load(std::memory_order_acquire) != KERN_SUCCESS) {
+        throw std::runtime_error("Unable to set thread name, error code " + std::to_string(ret));
+    }
+
 #elif defined __linux__ || defined __unix__
 	auto ret = pthread_setname_np(handle, name);
 
@@ -109,23 +142,13 @@ Result set_name([[maybe_unused]] auto& handle, const char* name) {
 }
 
 Result set_name(std::jthread& thread, const char* name) {
-#ifndef TARGET_OS_MAC
 	const auto handle = thread.native_handle();
 	return set_name(handle, name);
-#else
-	#pragma message WARN("Setting thread names is not implemented for this platform. Implement it, please!")
-	return Result::unsupported;
-#endif
 }
 
 Result set_name(std::thread& thread, const char* name) {
-#ifndef TARGET_OS_MAC
 	const auto handle = thread.native_handle();
 	return set_name(handle, name);
-#else
-	#pragma message WARN("Setting thread names is not implemented for this platform. Implement it, please!")
-	return Result::unsupported;
-#endif
 }
 
 Result set_name(const char* name) {
@@ -227,6 +250,5 @@ unsigned int hardware_concurrency(log::Logger& logger) {
 unsigned int hardware_concurrency() {
 	return hardware_concurrency(nullptr);
 }
-
 
 } // thread, ember


### PR DESCRIPTION
A name cannot be set directly on another thread, it can only be set on itself, but it can be staged as a self instruct and send it off with a signal handler to another thread. This can be used for reporting back on the status of the request. This is needed in order to achieve unity where the function throws an error if it fails; we need feedback to know if it failed.

Sadly not as direct or controlled as on windows/linux, but it's possible. Removing the check can result in a bad read during a race condition. 
The tester for instance is one such case as it doesn't give the scheduler enough time to process the request but instead immediately requesting a get_name and failing - give it 1 microsecond or allow the flag to report back and it passes, so it's not that mac doesn't want to set the name, it just wants to do it on it's own accord...

![Screenshot 2025-04-28 at 15 09 12](https://github.com/user-attachments/assets/cee44a32-75e5-4b69-8110-d1054294fe6f)
