### PR TITLE
libc++ compiler warning: uninitialized when used

### DIFF
--- a/src/login/NetworkSession.h
+++ b/src/login/NetworkSession.h
@@ -45,9 +45,9 @@ private:
 	boost::asio::steady_timer timer_;
 
 	Buffer inbound_buffer_;
+	std::array<Buffer, 2> outbound_buffers_{};
 	Buffer* outbound_front_;
 	Buffer* outbound_back_;
-	std::array<Buffer, 2> outbound_buffers_{};
 	bool write_in_progress_;
 	bool is_active_;
 


### PR DESCRIPTION
```
In file included from /Users/holsthein/Documents/GitHub/Ember/src/login/LoginSession.cpp:9:
In file included from /Users/holsthein/Documents/GitHub/Ember/src/login/LoginSession.h:12:
/Users/holsthein/Documents/GitHub/Ember/src/login/NetworkSession.h:181:22: warning: field 'outbound_buffers_' is uninitialized when used here [-Wuninitialized]
  181 |                   outbound_front_(&outbound_buffers_.front()),
      |                                    ^
/Users/holsthein/Documents/GitHub/Ember/src/login/LoginSession.cpp:25:5: note: in instantiation of member function 'ember::NetworkSession<ember::LoginSession>::NetworkSession' requested here
   25 |                 : NetworkSession(sessions, std::move(socket), logger),
      |                   ^
In file included from /Users/holsthein/Documents/GitHub/Ember/src/login/LoginSession.cpp:9:
In file included from /Users/holsthein/Documents/GitHub/Ember/src/login/LoginSession.h:12:
/Users/holsthein/Documents/GitHub/Ember/src/login/NetworkSession.h:182:21: warning: field 'outbound_buffers_' is uninitialized when used here [-Wuninitialized]
  182 |                   outbound_back_(&outbound_buffers_.back()),
      |                                   ^
```

Just reordered the declarations slightly