### PR TITLE
libc++ compiler warning: explicitly defaulted default constructor is implicitly deleted

### DIFF
--- a/src/libs/ports/include/ports/upnp/IGDevice.h
+++ b/src/libs/ports/include/ports/upnp/IGDevice.h
@@ -101,10 +101,10 @@ public:
 	IGDevice(boost::asio::io_context& ctx_, std::string bind,
 	         std::string service, const std::string& location);
 
-	IGDevice(IGDevice&) = default;
-	IGDevice(IGDevice&&) = default;
-	IGDevice& operator=(IGDevice&) = default;
-	IGDevice& operator=(IGDevice&&) = default;
+	IGDevice(IGDevice&) = delete;
+	IGDevice(IGDevice&&) = delete;
+	IGDevice& operator=(IGDevice&) = delete;
+	IGDevice& operator=(IGDevice&&) = delete;
 
 	void add_port_mapping(Mapping mapping, Result cb);
 	std::future<ErrorCode> add_port_mapping(const Mapping& mapping, use_future_t);

--- a/src/libs/spark/include/spark/Channel.h
+++ b/src/libs/spark/include/spark/Channel.h
@@ -53,7 +53,7 @@ public:
 	        Handler* handler, std::shared_ptr<Connection> connection,
 	        log::Logger& logger);
 
-	Channel() = default;
+	Channel() = delete;
 	~Channel();
 
 	Handler* handler() const;


### PR DESCRIPTION
```
(...)
warning: explicitly defaulted default constructor is implicitly deleted [-Wdefaulted-function-deleted]
   56 |         Channel() = default;
      |         ^
/Users/holsthein/Documents/GitHub/Ember/src/libs/spark/include/spark/Channel.h:39:11: note: default constructor of 'Channel' is implicitly deleted because field 'tracking_' has no default constructor
   39 |         Tracking tracking_;
      |                  ^
/Users/holsthein/Documents/GitHub/Ember/src/libs/spark/include/spark/Channel.h:56:14: note: replace 'default' with 'delete'
   56 |         Channel() = default;
(...)
```

Just explicitly marked them as delete