### PR TITLE
[RFC] Have non-clang aarch64 use __asm__ volatile("yield" ::: "memory")

### DIFF
--- a/src/libs/shared/shared/threading/Spinlock.h
+++ b/src/libs/shared/shared/threading/Spinlock.h
@@ -11,12 +11,18 @@
 #include <atomic>
 #include <thread>
 
+#if defined __APPLE__
+	#include <TargetConditionals.h>
+#endif
+
 #if defined(__x86_64__) || defined(_M_X64) || defined(i386) || defined(__i386__) || defined(__i386) || defined(_M_IX86)
 #define YIELD_INSTRUCTION _mm_pause()
 #define ember_x86_or_x64
-#elif defined(__APPLE__) && defined(__aarch64__)
+#elif defined(TARGET_OS_MAC) && defined(__aarch64__)
 #define YIELD_INSTRUCTION __builtin_arm_yield()
-#elif defined(__arm__) || defined(_M_ARM) || defined(_M_ARM64) || defined(_M_ARM64EC) || defined(__aarch64__)
+#elif defined(__aarch64__)
+#define YIELD_INSTRUCTION __asm__ volatile("yield" ::: "memory")
+#elif defined(__arm__) || defined(_M_ARM) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #define YIELD_INSTRUCTION __yield()
 #endif
 


### PR DESCRIPTION
Getting this error on ubuntu-arm:
```
70.52 /usr/src/ember/src/libs/shared/shared/threading/Spinlock.h: In member function 'void ember::Spinlock::lock()':
70.52 /usr/src/ember/src/libs/shared/shared/threading/Spinlock.h:20:27: error: '__yield' was not declared in this scope
70.52    20 | #define YIELD_INSTRUCTION __yield()
70.52       |                           ^~~~~~~
70.52 /usr/src/ember/src/libs/shared/shared/threading/Spinlock.h:54:33: note: in expansion of macro 'YIELD_INSTRUCTION'
70.52    54 |                                 YIELD_INSTRUCTION;
70.52       |
```