### PR TITLE
Nonintrusive 'local' caching of docker buildrunner

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,10 +9,24 @@ on:
 jobs:
 
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)
+      - name: Checkout Code
+        uses: actions/checkout@v4.2.2
+
+      - name: Docker Cache
+        uses: actions/cache@v3
+        with:
+          path: /tmp/docker-cache
+          key: docker-cache-${{ runner.os }}-${{ hashFiles('Dockerfile') }}
+          restore-keys: docker-cache-${{ runner.os }}
+
+      - name: Build the Docker image
+        run: |
+          docker buildx create --use --name mybuilder || docker buildx use mybuilder
+          docker buildx build \
+            --load \
+            --file Dockerfile \
+            --cache-from=type=local,src=/tmp/docker-cache \
+            --cache-to=type=local,dest=/tmp/docker-cache,mode=max \
+            .


### PR DESCRIPTION
title says it all, but for details;
- need to use buildx for advanced functionality (caching) 
- need to create a custom builder to enable said advanced functions first. 

Save layers to a cache folder so they can be loaded on subsequent runs.