### PR TITLE
Boost 1.88

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,6 @@
 cmake_minimum_required(VERSION 3.30)
 project(Ember)
 
-# Disable Boost warnings for now
-cmake_policy(SET CMP0167 OLD)
-
 option(BUILD_OPT_TOOLS "Build optional tools" ON)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
@@ -84,7 +81,6 @@ set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.87.0 REQUIRED COMPONENTS program_options system)
-include_directories(${Boost_INCLUDE_DIRS})
 
 ##############################
 #             Git            #

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,9 @@ RUN apt-get -y update && apt-get -y upgrade \
  && apt-get install -y zlib1g-dev \
  && apt-get install -y libpcre3-dev \
  && apt-get install -y libflatbuffers-dev \
- && wget -q https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.gz \
- && tar -zxf boost_1_87_0.tar.gz \
- && cd boost_1_87_0 \
+ && wget -q https://archives.boost.io/release/1.88.0/source/boost_1_88_0.tar.gz \
+ && tar -zxf boost_1_88_0.tar.gz \
+ && cd boost_1_88_0 \
  && ./bootstrap.sh --with-libraries=system,program_options,headers \
  && ./b2 link=static install -d0 -j $(nproc) cxxflags="-std=c++23"
 

--- a/src/libs/srp6/CMakeLists.txt
+++ b/src/libs/srp6/CMakeLists.txt
@@ -19,5 +19,6 @@ add_library(${LIBRARY_NAME}
 			include/srp6/detail/Primes.h
            )
 
+target_link_libraries(${LIBRARY_NAME} PRIVATE ${Boost_LIBRARIES})
 target_include_directories(${LIBRARY_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set_target_properties(${LIBRARY_NAME} PROPERTIES FOLDER "Common Libraries")


### PR DESCRIPTION
- Bump the docker-image boost version to 1.88
- stop hiding warnings
- stop broadcasting boost_include_dirs through the entire project:
removing include_directories(${Boost_INCLUDE_DIRS}) from the top level cmakelists stops passing it onto every module (which it shouldn't), which in turn then requires proper linking of boost to every module needing it; which turned out to only be missing from srp6.