### PR TITLE
Update README.MD for target platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ We have a Discord server over at [https://discord.gg/WpPJzQS](https://discord.gg
 
 Ember aims to support the following platforms as a minimum:
 
-| Operating System  | Architectures |
-| :------------ |:---------------:|
-| Linux         | x86, x64, ARMv7 |
-| Windows       | x86, x64        |
-| Mac OS        | x86, x64        |
+| Operating System | Architectures |
+| :--------------- |:-------------:|
+| Windows          | x64, ARM64    |
+| macOS            | Apple Silicon |
+| Linux            | x64, ARM64    |
 
 ## ⚙️ Supported compilers
 

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Ember aims to support the following platforms as a minimum:
 
 | Operating System | Architectures |
 | :--------------- |:-------------:|
-| Windows          | x64, ARM64    |
-| macOS            | Apple Silicon |
-| Linux            | x64, ARM64    |
+| <img src="https://upload.wikimedia.org/wikipedia/commons/8/87/Windows_logo_-_2021.svg" alt="Windows Logo" width="20" height="20" style="vertical-align: middle; margin-left: 4px;"> Windows | x86_64, ARM64 |
+| <img src="https://upload.wikimedia.org/wikipedia/commons/a/ab/Icon-Mac.svg" alt="Apple Logo" width="20" height="20" style="vertical-align: middle; margin-left: 4px;"> macOS                | Apple Silicon |
+| <img src="https://upload.wikimedia.org/wikipedia/commons/a/af/Tux.png" alt="Linux (Tux) Logo" width="20" height="20" style="vertical-align: middle; margin-left: 4px;"> Linux               | x86_64, ARM64 |
 
 ## ⚙️ Supported compilers
 


### PR DESCRIPTION
Update the target platforms that are actually gonna be supported;
- x32 support dropped from all platforms,
- x64 support dropped from macOS (no dirty old intel macs)
- ARM support normalized/extended to all platforms (in the form of ARM64)

| Operating System | Architectures |
| :--------------- |:-------------:|
| <img src="https://upload.wikimedia.org/wikipedia/commons/8/87/Windows_logo_-_2021.svg" alt="Windows Logo" width="20" height="20" style="vertical-align: middle; margin-left: 4px;"> Windows   | x86_64, ARM64    |
| <img src="https://upload.wikimedia.org/wikipedia/commons/a/ab/Icon-Mac.svg" alt="Apple Logo" width="20" height="20" style="vertical-align: middle; margin-left: 4px;"> macOS                  | Apple Silicon |
| <img src="https://upload.wikimedia.org/wikipedia/commons/a/af/Tux.png" alt="Linux (Tux) Logo" width="20" height="20" style="vertical-align: middle; margin-left: 4px;"> Linux                 | x86_64, ARM64    |

Why change the order up? Because from a game perspective, Windows was always the main target platform, it belongs on the top, macOS being the secondary supported platform it deserves the second spot. This also fits better with the order of supported compilers (seeing it's going from msvc, to clang, to gcc, which would be the typical compilers on windows, macOS and linux, in that order respectively)