### PR TITLE
[msvc] cmake linking: msvc will not wait for spark_generated.h to be generated without creating and setting post-generation target as dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ include_directories(${MYSQLCCPP_INCLUDE_DIRS})
 ##############################
 #         FlatBuffers        #
 ##############################
-find_package(FlatBuffers 2.0.8 REQUIRED)
+find_package(flatbuffers 2.0.8 REQUIRED)
 
 ##############################
 #            zlib            #

--- a/schemas/CMakeLists.txt
+++ b/schemas/CMakeLists.txt
@@ -1,10 +1,12 @@
-# Copyright (c) 2016 - 2024 Ember
+# Copyright (c) 2016 - 2025 Ember
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 set(FB_SCHEMA_TARGET_NAME FB_SCHEMA_COMPILE)
+
+set(BINARY_SCHEMAS_DIR ${CMAKE_BINARY_DIR}/schemas/FB_SCHEMA_COMPILE)
 
 set(SERVICE_SCHEMAS
     ${CMAKE_CURRENT_SOURCE_DIR}/spark/services/Account.fbs
@@ -25,10 +27,16 @@ flatbuffers_generate_headers(
   TARGET              ${FB_SCHEMA_TARGET_NAME}
   SCHEMAS             ${FB_SCHEMAS}
   INCLUDE             ${CMAKE_CURRENT_SOURCE_DIR}
-  BINARY_SCHEMAS_DIR  ${CMAKE_BINARY_DIR}
+  BINARY_SCHEMAS_DIR  ${BINARY_SCHEMAS_DIR}
   FLAGS               ${FLATC_ARGS}
+  BYPRODUCTS          ${BINARY_SCHEMAS_DIR}/Spark_generated.h
 )
 
-target_include_directories(${FB_SCHEMA_TARGET_NAME} INTERFACE ${CMAKE_BINARY_DIR}/schemas/FB_SCHEMA_COMPILE)
+target_link_libraries(${FB_SCHEMA_TARGET_NAME} INTERFACE flatbuffers::flatbuffers)
+target_include_directories(${FB_SCHEMA_TARGET_NAME} INTERFACE ${BINARY_SCHEMAS_DIR})
+
+# MSVC requires a post-compile target to depend upon or it will not respsect build order
+add_custom_target(GenerateSparkHeaders ALL DEPENDS ${BINARY_SCHEMAS_DIR}/Spark_generated.h)
+
 set(TEMPLATE_DIR ${CMAKE_SOURCE_DIR}/src/tools/rpcgen/templates/)
-build_spark_services("${SERVICE_SCHEMAS}" ${TEMPLATE_DIR} ${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR})
+build_spark_services("${SERVICE_SCHEMAS}" ${TEMPLATE_DIR} ${BINARY_SCHEMAS_DIR} ${BINARY_SCHEMAS_DIR})

--- a/src/account/CMakeLists.txt
+++ b/src/account/CMakeLists.txt
@@ -25,9 +25,8 @@ set(LIBRARY_SRC
 include_directories(${SPARK_INCLUDES_DIR})
 
 add_library(${LIBRARY_NAME} STATIC ${LIBRARY_HDR} ${LIBRARY_SRC})
-target_link_libraries(${LIBRARY_NAME} PRIVATE spark conpool logger shared ${MYSQLCCPP_LIBRARY} 
-                                      ${BOTAN_LIBRARY} ${Boost_LIBRARIES} Threads::Threads FB_SCHEMA_COMPILE)
-target_include_directories(${LIBRARY_NAME} PUBLIC ${CMAKE_BINARY_DIR})
+target_link_libraries(${LIBRARY_NAME} logger shared spark conpool ${MYSQLCCPP_LIBRARY}
+                                      ${Boost_LIBRARIES} ${BOTAN_LIBRARY} Threads::Threads)
 
 add_executable(${EXECUTABLE_NAME} main.cpp)
 target_link_libraries(${EXECUTABLE_NAME} ${LIBRARY_NAME} logger shared ${Boost_LIBRARIES} Threads::Threads)

--- a/src/character/CMakeLists.txt
+++ b/src/character/CMakeLists.txt
@@ -24,13 +24,12 @@ set(LIBRARY_SRC
 include_directories(${CMAKE_SOURCE_DIR}/deps/utf8cpp)
 
 add_library(${LIBRARY_NAME} STATIC ${LIBRARY_HDR} ${LIBRARY_SRC})
-target_link_libraries(${LIBRARY_NAME} dbcreader spark logger protocol shared ${BOTAN_LIBRARY} 
-                                      ${Boost_LIBRARIES} Threads::Threads FB_SCHEMA_COMPILE)
-target_include_directories(${LIBRARY_NAME} PUBLIC ${CMAKE_BINARY_DIR})
+target_link_libraries(${LIBRARY_NAME} logger shared dbcreader spark protocol ${MYSQLCCPP_LIBRARY}
+                                      ${Boost_LIBRARIES} ${BOTAN_LIBRARY} Threads::Threads)
 
 add_executable(${EXECUTABLE_NAME} main.cpp)
-target_link_libraries(${EXECUTABLE_NAME} ${LIBRARY_NAME} protocol dbcreader spark conpool logger shared 
-                                                         ${MYSQLCCPP_LIBRARY} ${Boost_LIBRARIES} Threads::Threads)
+target_link_libraries(${EXECUTABLE_NAME} ${LIBRARY_NAME} logger shared protocol dbcreader spark conpool
+                                         ${Boost_LIBRARIES} Threads::Threads)
 
 INSTALL(TARGETS ${EXECUTABLE_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX})
 set_target_properties(character PROPERTIES FOLDER "Services/Applications")

--- a/src/fusion/CMakeLists.txt
+++ b/src/fusion/CMakeLists.txt
@@ -17,7 +17,7 @@ set(SERVICE_LIBRARIES
     libcharacter
 )
 
-target_link_libraries(${EXECUTABLE_NAME} ${LIBRARY_NAME} logger shared ${SERVICE_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${EXECUTABLE_NAME} logger shared ${SERVICE_LIBRARIES} ${Boost_LIBRARIES})
 target_include_directories(${EXECUTABLE_NAME} PRIVATE ../)
 
 INSTALL(TARGETS ${EXECUTABLE_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX})

--- a/src/gateway/CMakeLists.txt
+++ b/src/gateway/CMakeLists.txt
@@ -84,10 +84,8 @@ set(LIBRARY_SRC
     )
 
 add_library(${LIBRARY_NAME} STATIC ${LIBRARY_HDR} ${LIBRARY_SRC})
-add_dependencies(${LIBRARY_NAME} FB_SCHEMA_COMPILE)
-target_link_libraries(${LIBRARY_NAME} PRIVATE ${Boost_LIBRARIES} PRIVATE nsd conpool stun ports dbcreader protocol spark 
-                                             logger shared ${ZLIB_LIBRARY} ${BOTAN_LIBRARY} Threads::Threads)
-target_include_directories(${LIBRARY_NAME} PUBLIC ${CMAKE_BINARY_DIR})
+target_link_libraries(${LIBRARY_NAME} logger shared nsd conpool stun ports dbcreader protocol spark
+                                      ${Boost_LIBRARIES} ${BOTAN_LIBRARY} ${MYSQLCCPP_LIBRARY} Threads::Threads)
 
 add_executable(${EXECUTABLE_NAME} main.cpp)
 target_link_libraries(${EXECUTABLE_NAME} ${LIBRARY_NAME} logger shared ${Boost_LIBRARIES} Threads::Threads)

--- a/src/libs/mpq/CMakeLists.txt
+++ b/src/libs/mpq/CMakeLists.txt
@@ -54,8 +54,7 @@ add_library(${LIBRARY_NAME}
     src/Utility.cpp
 )
 
-target_link_libraries(${LIBRARY_NAME} shared storm_pklib
-                      bzip2 lzma storm_adpcm storm_sparse storm_huffman
-                      ${Boost_LIBRARIES} ${ZLIB_LIBRARY})
+target_link_libraries(${LIBRARY_NAME} shared bzip2 lzma storm_pklib storm_adpcm storm_sparse
+                                      storm_huffman ${Boost_LIBRARIES} ZLIB::ZLIB)
 target_include_directories(${LIBRARY_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set_target_properties(${LIBRARY_NAME} PROPERTIES FOLDER "Common Libraries")

--- a/src/libs/protocol/CMakeLists.txt
+++ b/src/libs/protocol/CMakeLists.txt
@@ -52,6 +52,6 @@ source_group("Core Headers" FILES ${CORE_HEADERS})
 
 add_library(${LIBRARY_NAME} INTERFACE)
 target_sources(${LIBRARY_NAME} INTERFACE ${HEADERS})
-target_link_libraries(${LIBRARY_NAME} INTERFACE shared spark ${Boost_LIBRARIES})
+target_link_libraries(${LIBRARY_NAME} INTERFACE shared spark ${Boost_LIBRARIES} ZLIB::ZLIB)
 target_include_directories(${LIBRARY_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set_target_properties(${LIBRARY_NAME} PROPERTIES FOLDER "Common Libraries")

--- a/src/libs/shared/CMakeLists.txt
+++ b/src/libs/shared/CMakeLists.txt
@@ -136,6 +136,6 @@ source_group("Metrics" FILES ${METRICS_SRC})
 
 include_directories(${CMAKE_SOURCE_DIR}/deps/utf8cpp ${PROJECT_BINARY_DIR}/src)
 add_library(${LIBRARY_NAME} ${LIBRARY_SRC})
-target_include_directories(${LIBRARY_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/)
 target_link_libraries(${LIBRARY_NAME} PUBLIC logger conpool ${PCRE_LIBRARY})
+target_include_directories(${LIBRARY_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/)
 set_target_properties(${LIBRARY_NAME} PROPERTIES FOLDER "Common Libraries")

--- a/src/libs/spark/CMakeLists.txt
+++ b/src/libs/spark/CMakeLists.txt
@@ -38,7 +38,7 @@ set(IO_SRC
     include/spark/buffers/BufferSequence.h
     include/spark/buffers/BinaryStream.h
     include/spark/buffers/StaticBuffer.h
-	include/spark/buffers/Concepts.h
+    include/spark/buffers/Concepts.h
     include/spark/buffers/detail/IntrusiveStorage.h
     include/spark/buffers/FileBuffer.h
     include/spark/buffers/Endian.h
@@ -71,7 +71,7 @@ add_library(
     ${CORE}
     ${IO_SRC}
     ${IO_PMR_SRC}
-	${IO_ALLOC_SRC}
+    ${IO_ALLOC_SRC}
 )
 
 source_group("Core" FILES ${CORE})
@@ -80,5 +80,6 @@ source_group("IO\\Polymorphic" FILES ${IO_PMR_SRC})
 source_group("IO\\Allocators" FILES ${IO_ALLOC_SRC})
 
 target_link_libraries(${LIBRARY_NAME} shared ${Boost_LIBRARIES} FB_SCHEMA_COMPILE)
+add_dependencies(${LIBRARY_NAME} GenerateSparkHeaders)
 target_include_directories(${LIBRARY_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set_target_properties(${LIBRARY_NAME} PROPERTIES FOLDER "Common Libraries")

--- a/src/login/CMakeLists.txt
+++ b/src/login/CMakeLists.txt
@@ -87,9 +87,8 @@ set(LIBRARY_SRC
 source_group("Grunt Protocol" FILES ${GRUNT_SRC})
 
 add_library(${LIBRARY_NAME} STATIC ${LIBRARY_HDR} ${LIBRARY_SRC} ${GRUNT_SRC})
-target_link_libraries(${LIBRARY_NAME} dbcreader spark srp6 logger stun ports shared ${ZLIB_LIBRARY}
-                                      ${BOTAN_LIBRARY} ${Boost_LIBRARIES} Threads::Threads FB_SCHEMA_COMPILE)
-target_include_directories(${LIBRARY_NAME} PUBLIC ${CMAKE_BINARY_DIR})
+target_link_libraries(${LIBRARY_NAME} logger shared dbcreader spark srp6 stun ports ${Boost_LIBRARIES}
+                                      ${BOTAN_LIBRARY} ${MYSQLCCPP_LIBRARY} ZLIB::ZLIB Threads::Threads)
 
 add_executable(${EXECUTABLE_NAME} main.cpp)
 target_link_libraries(${EXECUTABLE_NAME} ${LIBRARY_NAME} logger shared ${Boost_LIBRARIES} Threads::Threads)

--- a/src/mdns/CMakeLists.txt
+++ b/src/mdns/CMakeLists.txt
@@ -33,8 +33,7 @@ set(LIBRARY_SRC
     )
 
 add_library(${LIBRARY_NAME} STATIC ${LIBRARY_HDR} ${LIBRARY_SRC})
-target_link_libraries(${LIBRARY_NAME} PRIVATE logger shared spark ${Boost_LIBRARIES} Threads::Threads FB_SCHEMA_COMPILE)
-target_include_directories(${LIBRARY_NAME} PUBLIC ${CMAKE_BINARY_DIR})
+target_link_libraries(${LIBRARY_NAME} PRIVATE logger shared spark ${Boost_LIBRARIES} Threads::Threads)
 
 add_executable(${EXECUTABLE_NAME} main.cpp)
 target_link_libraries(${EXECUTABLE_NAME} ${LIBRARY_NAME} logger shared ${Boost_LIBRARIES} Threads::Threads)

--- a/src/social/CMakeLists.txt
+++ b/src/social/CMakeLists.txt
@@ -17,7 +17,7 @@ set(LIBRARY_SRC
     )
 
 add_library(${LIBRARY_NAME} STATIC ${LIBRARY_HDR} ${LIBRARY_SRC})
-target_link_libraries(${LIBRARY_NAME} logger shared ${Boost_LIBRARIES} FB_SCHEMA_COMPILE)
+target_link_libraries(${LIBRARY_NAME} logger shared ${Boost_LIBRARIES})
 
 add_executable(${EXECUTABLE_NAME} main.cpp)
 target_link_libraries(${EXECUTABLE_NAME} ${LIBRARY_NAME} spark logger shared ${Boost_LIBRARIES} Threads::Threads)

--- a/src/tools/rpcgen/CMakeLists.txt
+++ b/src/tools/rpcgen/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 - 2024 Ember
+# Copyright (c) 2021 - 2025 Ember
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -10,12 +10,13 @@ set(EXECUTABLE_SRC
     main.cpp
     SchemaParser.h
     SchemaParser.cpp
-	Utility.h
-	Utility.cpp
-    )
+    Utility.h
+    Utility.cpp
+)
 
 include_directories(${CMAKE_SOURCE_DIR}/deps/nlohmann)
 add_executable(${EXECUTABLE_NAME} ${EXECUTABLE_SRC})
 target_link_libraries(${EXECUTABLE_NAME} logger shared ${Boost_LIBRARIES} FB_SCHEMA_COMPILE)
+add_dependencies(${EXECUTABLE_NAME} GenerateSparkHeaders)
 INSTALL(TARGETS ${EXECUTABLE_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/tools)
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES FOLDER "Tools")

--- a/src/world/CMakeLists.txt
+++ b/src/world/CMakeLists.txt
@@ -24,7 +24,7 @@ set(LIBRARY_SRC
     )
 
 add_library(${LIBRARY_NAME} ${LIBRARY_HDR} ${LIBRARY_SRC})
-target_link_libraries(${LIBRARY_NAME} dbcreader spark logger shared ${Boost_LIBRARIES})
+target_link_libraries(${LIBRARY_NAME} logger shared dbcreader spark ${Boost_LIBRARIES})
 
 add_executable(${EXECUTABLE_NAME} main.cpp)
 target_link_libraries(${EXECUTABLE_NAME} ${LIBRARY_NAME} logger shared ${Boost_LIBRARIES})


### PR DESCRIPTION
Issue: Spark_generated.h and similar headers generated during compile is not waited upon by msvc even when setting the target as a dependency.

Solution: Make a post-generation target and make the modules depend upon that instead as that will force msvc to ensure the headers are actually generated before they're needed.

Windows should now successfully build the first time. This is crucial preliminary work for the windows buildrunner as it cannot fail any step unlike locally where we can just re-build (as msvc seems to generate them right after they're needed and then failing, but them now existing in the build directory so a subsequent dirty build will succeed).

Also pulled out the schema headers from where they are actually not needed, only 2 modules depend upon them; rpcgen and spark.