### PR TITLE
Split MPQ decryption look-up table

### DIFF
--- a/src/libs/mpq/CMakeLists.txt
+++ b/src/libs/mpq/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 - 2025 Ember
+# Copyright (c) 2024 - 2026 Ember
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -25,7 +25,7 @@ set(ARCHIVE_V1
     src/v1/MemoryArchive.cpp
 )
 
-source_group("Archive" FILES ${ARCHIVE})
+source_group("Archive"     FILES ${ARCHIVE})
 source_group("Archive\\v0" FILES ${ARCHIVE_V0})
 source_group("Archive\\v1" FILES ${ARCHIVE_V1})
 
@@ -38,6 +38,7 @@ add_library(${LIBRARY_NAME}
     include/mpq/ErrorCode.h
     include/mpq/Structures.h
     include/mpq/Crypt.h
+    include/mpq/CryptTable.h
     include/mpq/Compression.h
     include/mpq/Exception.h
     include/mpq/SharedDefs.h
@@ -48,6 +49,7 @@ add_library(${LIBRARY_NAME}
     include/mpq/DynamicMemorySink.h
     include/mpq/Utility.h
     include/mpq/DecompressionError.h
+    src/CryptTable.cpp
     src/MPQ.cpp
     src/Compression.cpp
     src/PKCompression.cpp

--- a/src/libs/mpq/include/mpq/Crypt.h
+++ b/src/libs/mpq/include/mpq/Crypt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ember
+ * Copyright (c) 2024 - 2026 Ember
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -8,11 +8,12 @@
 
 #pragma once
 
+#include <mpq/CryptTable.h>
 #include <shared/utility/polyfill/start_lifetime_as>
-#include <array>
-#include <bit>
 #include <span>
+#include <type_traits>
 #include <cctype>
+#include <cstddef>
 #include <cstdint>
 
 // Thanks to https://www.zezula.net/en/mpq/techinfo.html for these time-savers
@@ -20,32 +21,14 @@
 
 namespace ember::mpq {
 
-[[nodiscard]] static consteval auto crypt_table() {
-    std::array<std::uint32_t, 1280> table{};
-    std::uint32_t seed = 0x00100001;
-
-    for(std::uint32_t index1 = 0; index1 < 0x100; ++index1) { 
-        for(std::uint32_t i = 0, index2 = index1; i < 5; ++i, index2 += 0x100) { 
-            seed = (seed * 125 + 3) % 0x2AAAAB;
-            std::uint32_t val1 = (seed & 0xFFFF) << 0x10;
-            seed = (seed * 125 + 3) % 0x2AAAAB;
-            std::uint32_t val2 = (seed & 0xFFFF);
-            table[index2] = val1 | val2; 
-        }
-    } 
-
-    return table;
-}
-
 static constexpr void decrypt_block(std::span<std::byte> buffer, std::uint32_t key) {
-	constexpr auto table = crypt_table();
 	std::uint32_t seed = 0xEEEEEEEE;
 	std::span<std::uint32_t> cast_block { 
 		std::start_lifetime_as<std::uint32_t>(buffer.data()), buffer.size_bytes() >> 2 
 	};
 
 	for(auto& block : cast_block) {
-		seed += table[0x400 + (key & 0xFF)];
+		seed += CRYPT_TABLE[0x400 + (key & 0xFF)];
 		const auto ch = block ^ (key + seed);
 		key = ((~key << 0x15) + 0x11111111) | (key >> 0x0B);
 		seed = ch + seed + (seed << 5) + 3;
@@ -54,13 +37,12 @@ static constexpr void decrypt_block(std::span<std::byte> buffer, std::uint32_t k
 }
 
 static constexpr std::uint32_t hash_string(std::string_view key, std::uint32_t type) {
-	constexpr auto table = crypt_table();
 	std::uint32_t seed1 = 0x7FED7FED;
 	std::uint32_t seed2 = 0xEEEEEEEE;
 
 	for(auto byte : key) {
 		auto ch = std::toupper(byte);
-		seed1 = table[(type << 8) + ch] ^ (seed1 + seed2);
+		seed1 = CRYPT_TABLE[(type << 8) + ch] ^ (seed1 + seed2);
 		seed2 = ch + seed1 + seed2 + (seed2 << 5) + 3;
 	}
 

--- a/src/libs/mpq/include/mpq/CryptTable.h
+++ b/src/libs/mpq/include/mpq/CryptTable.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024 - 2026 Ember
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <array>
+#include <type_traits>
+#include <cstdint>
+
+// Thanks to https://www.zezula.net/en/mpq/techinfo.html for these time-savers
+// Same functions, just modernised a bit
+
+namespace ember::mpq {
+
+[[nodiscard]] static consteval auto crypt_table() {
+    std::array<std::uint32_t, 1280> table{};
+    std::uint32_t seed = 0x00100001;
+
+    for(std::uint32_t index1 = 0; index1 < 0x100; ++index1) { 
+        for(std::uint32_t i = 0, index2 = index1; i < 5; ++i, index2 += 0x100) { 
+            seed = (seed * 125 + 3) % 0x2AAAAB;
+            std::uint32_t val1 = (seed & 0xFFFF) << 0x10;
+            seed = (seed * 125 + 3) % 0x2AAAAB;
+            std::uint32_t val2 = (seed & 0xFFFF);
+            table[index2] = val1 | val2; 
+        }
+    } 
+
+    return table;
+}
+
+extern const std::invoke_result<decltype(&crypt_table)>::type CRYPT_TABLE;
+
+} // mpq, ember

--- a/src/libs/mpq/src/CryptTable.cpp
+++ b/src/libs/mpq/src/CryptTable.cpp
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Ember
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <mpq/CryptTable.h>
+
+namespace ember::mpq {
+
+const std::invoke_result<decltype(&crypt_table)>::type CRYPT_TABLE = crypt_table();
+
+} // mpq, ember

--- a/src/libs/mpq/src/Utility.cpp
+++ b/src/libs/mpq/src/Utility.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ember
+ * Copyright (c) 2024 - 2026 Ember
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -7,7 +7,7 @@
  */
 
 #include <mpq/Utility.h>
-#include <mpq/Crypt.h>
+#include <mpq/CryptTable.h>
 #include <tuple>
 #include <utility>
 
@@ -15,9 +15,7 @@ namespace ember::mpq {
 
 // This is ported from StormLib, credits to Ladislav Zezula
 // Original source: SBaseCommon.cpp (MIT licensed)
-constexpr std::optional<std::uint32_t> key_recover(std::span<const std::uint32_t> sectors,
-                                                   const std::uint32_t sector_size) {
-	constexpr auto table = crypt_table();
+constexpr std::optional<std::uint32_t> key_recover(std::span<const std::uint32_t> sectors, const std::uint32_t sector_size) {
 	std::uint32_t expected = sectors.size_bytes();
 
 	if(sectors.size() < 2) {
@@ -32,10 +30,10 @@ constexpr std::optional<std::uint32_t> key_recover(std::span<const std::uint32_t
 		std::uint32_t data[2]{};
 
 		for(std::uint32_t j = 0; j < 0x100; ++j) {
-			std::uint32_t key1 = combined_keys - table[0x400 + j];
+			std::uint32_t key1 = combined_keys - CRYPT_TABLE[0x400 + j];
 			std::uint32_t key2 = 0xEEEEEEEE;
 
-			key2 += table[0x400 + (key1 & 0xFF)];
+			key2 += CRYPT_TABLE[0x400 + (key1 & 0xFF)];
 			data[0] = sectors[0] ^ (key1 + key2);
 
 			if(data[0] == expected) {
@@ -44,7 +42,7 @@ constexpr std::optional<std::uint32_t> key_recover(std::span<const std::uint32_t
 				key1 = ((~key1 << 0x15) + 0x11111111) | (key1 >> 0x0B);
 				key2 = data[0] + key2 + (key2 << 5) + 3;
 
-				key2 += table[0x400 + (key1 & 0xFF)];
+				key2 += CRYPT_TABLE[0x400 + (key1 & 0xFF)];
 				data[1] = sectors[1] ^ (key1 + key2);
 
 				if(data[1] <= max_value) {

--- a/src/libs/ports/src/upnp/HTTPTransport.cpp
+++ b/src/libs/ports/src/upnp/HTTPTransport.cpp
@@ -12,7 +12,6 @@
 #include <boost/asio/as_tuple.hpp>
 #include <boost/asio/connect.hpp>
 #include <boost/asio/write.hpp>
-#include <boost/asio/deferred.hpp>
 #include <boost/asio/ip/basic_resolver.hpp>
 #include <stdexcept>
 
@@ -32,18 +31,18 @@ HTTPTransport::~HTTPTransport() {
 }
 
 ba::awaitable<void> HTTPTransport::connect(std::string_view host, const std::uint16_t port) {
-	auto results = co_await resolver_.async_resolve(host, std::to_string(port),ba::deferred);
-	co_await ba::async_connect(socket_, results, ba::deferred);
+	auto results = co_await resolver_.async_resolve(host, std::to_string(port));
+	co_await ba::async_connect(socket_, results);
 }
 
 ba::awaitable<void> HTTPTransport::send(std::shared_ptr<std::vector<std::uint8_t>> message) {
 	auto buffer = ba::buffer(*message);
-	co_await ba::async_write(socket_, buffer, ba::as_tuple(ba::deferred));
+	co_await ba::async_write(socket_, buffer, ba::as_tuple);
 }
 
 ba::awaitable<void> HTTPTransport::send(std::vector<std::uint8_t> message) {
 	auto data = std::make_shared<std::vector<std::uint8_t>>(std::move(message));
-	co_await ba::async_write(socket_, ba::buffer(*data), ba::as_tuple(ba::deferred));
+	co_await ba::async_write(socket_, ba::buffer(*data), ba::as_tuple);
 }
 
 auto HTTPTransport::receive_http_response() -> ba::awaitable<Response> {
@@ -135,7 +134,7 @@ ba::awaitable<std::size_t> HTTPTransport::read(const std::size_t offset) {
 	}
 
 	const auto buffer = ba::buffer(buffer_.data() + offset, buffer_.size() - offset);
-	auto size = co_await socket_.async_receive(buffer, ba::deferred);
+	auto size = co_await socket_.async_receive(buffer);
 	co_return size;
 }
 

--- a/src/libs/ports/src/upnp/MulticastSocket.cpp
+++ b/src/libs/ports/src/upnp/MulticastSocket.cpp
@@ -8,33 +8,32 @@
 
 #include <ports/upnp/MulticastSocket.h>
 #include <boost/asio/as_tuple.hpp>
-#include <boost/asio/deferred.hpp>
 #include <boost/asio/ip/multicast.hpp>
 #include <utility>
 
 namespace ember::ports {
 
-MulticastSocket::MulticastSocket(boost::asio::io_context& context,
+MulticastSocket::MulticastSocket(ba::io_context& context,
 								 std::string_view listen_iface,
 								 std::string_view mcast_group,
 								 const std::uint16_t port)
 	: context_(context),
 	  socket_(context),
 	  buffer_{},
-	ep_(boost::asio::ip::make_address(mcast_group), port) {
-	const auto mcast_iface = boost::asio::ip::make_address(listen_iface);
-	const auto group_ip = boost::asio::ip::make_address(mcast_group);
+	ep_(ba::ip::make_address(mcast_group), port) {
+	const auto mcast_iface = ba::ip::make_address(listen_iface);
+	const auto group_ip = ba::ip::make_address(mcast_group);
 
-	boost::asio::ip::udp::endpoint ep(mcast_iface, 0);
+	ba::ip::udp::endpoint ep(mcast_iface, 0);
 	socket_.open(ep.protocol());
-	socket_.set_option(boost::asio::ip::udp::socket::reuse_address(true));
-	boost::asio::ip::multicast::join_group join_opt{};
+	socket_.set_option(ba::ip::udp::socket::reuse_address(true));
+	ba::ip::multicast::join_group join_opt{};
 
 	// Asio is doing something weird on Windows, this is a hack
 	if(mcast_iface.is_v4()) {
-		join_opt = boost::asio::ip::multicast::join_group(group_ip.to_v4(), mcast_iface.to_v4());
+		join_opt = ba::ip::multicast::join_group(group_ip.to_v4(), mcast_iface.to_v4());
 	} else {
-		join_opt = boost::asio::ip::multicast::join_group(group_ip);
+		join_opt = ba::ip::multicast::join_group(group_ip);
 	}
 
 	socket_.set_option(join_opt);
@@ -50,8 +49,8 @@ auto MulticastSocket::receive() -> ba::awaitable<ReceiveType> {
 		co_return std::unexpected(ba::error::not_connected);
 	}
 
-	auto buffer = boost::asio::buffer(buffer_);
-	auto [ec, size] = co_await socket_.async_receive_from(buffer, remote_ep_, ba::as_tuple(ba::deferred));
+	auto buffer = ba::buffer(buffer_);
+	auto [ec, size] = co_await socket_.async_receive_from(buffer, remote_ep_, ba::as_tuple);
 
 	if(ec) {
 		co_return std::unexpected(ec);
@@ -76,9 +75,9 @@ ba::awaitable<bool> MulticastSocket::send(std::shared_ptr<std::vector<std::uint8
 		co_return false;
 	}
 
-	const auto ba_buf = boost::asio::buffer(*buffer);
+	const auto ba_buf = ba::buffer(*buffer);
 
-	const auto& [ec, _] = co_await socket_.async_send_to(ba_buf, ep, boost::asio::as_tuple(ba::deferred));
+	const auto& [ec, _] = co_await socket_.async_send_to(ba_buf, ep, ba::as_tuple);
 
 	if(ec) {
 		socket_.close();
@@ -94,7 +93,7 @@ ba::awaitable<bool> MulticastSocket::send(std::shared_ptr<std::vector<std::uint8
 
 void MulticastSocket::close() {
 	boost::system::error_code ec; // we don't care about any errors
-	socket_.shutdown(boost::asio::ip::udp::socket::shutdown_both, ec);
+	socket_.shutdown(ba::ip::udp::socket::shutdown_both, ec);
 	socket_.close(ec);
 }
 

--- a/src/libs/spark/src/Connection.cpp
+++ b/src/libs/spark/src/Connection.cpp
@@ -10,7 +10,6 @@
 #include <spark/Exception.h>
 #include <logger/Logger.h>
 #include <boost/asio/co_spawn.hpp>
-#include <boost/asio/deferred.hpp>
 #include <boost/asio/detached.hpp>
 #include <boost/asio/read.hpp>
 #include <boost/asio/write.hpp>
@@ -41,7 +40,7 @@ ba::awaitable<void> Connection::process_queue() try {
 			ba::const_buffer { msg.fbb.GetBufferPointer(), msg.fbb.GetSize() }
 		};
 
-		co_await ba::async_write(socket_, buffers, ba::deferred);
+		co_await ba::async_write(socket_, buffers);
 	}
 } catch(const std::exception&) {
 	close();
@@ -73,7 +72,7 @@ ba::awaitable<std::size_t> Connection::read_until(const std::size_t offset,
 
 	while(received < read_size) {
 		auto buffer = ba::buffer(buffer_.data() + received, buffer_.size() - received);
-		received += co_await socket_.async_receive(buffer, ba::deferred);
+		received += co_await socket_.async_receive(buffer);
 	}
 
 	co_return received;
@@ -99,7 +98,7 @@ ba::awaitable<std::uint32_t>  Connection::do_receive() {
 
 	// read the message size
 	auto buf = boost::asio::buffer(buffer_.data(), sizeof(msg_size));
-	co_await socket_.async_read_some(buf, ba::deferred);
+	co_await socket_.async_read_some(buf);
 	
 	std::memcpy(&msg_size, buffer_.data(), sizeof(msg_size));
 	boost::endian::little_to_native_inplace(msg_size);
@@ -109,7 +108,7 @@ ba::awaitable<std::uint32_t>  Connection::do_receive() {
 	}
 
 	buf = boost::asio::buffer(buffer_.data() + sizeof(msg_size), msg_size - sizeof(msg_size));
-	co_await socket_.async_read_some(buf, ba::deferred);
+	co_await socket_.async_read_some(buf);
 	co_return msg_size;
 }
 
@@ -131,7 +130,7 @@ ba::awaitable<std::span<std::uint8_t>> Connection::receive_msg() {
 	std::uint32_t msg_size = 0;
 
 	auto buffer = ba::buffer(buffer_.data(), sizeof(msg_size));
-	co_await ba::async_read(socket_, buffer, ba::deferred);
+	co_await ba::async_read(socket_, buffer);
 	std::memcpy(&msg_size, buffer_.data(), sizeof(msg_size));
 
 	if(msg_size > buffer_.size()) {
@@ -140,7 +139,7 @@ ba::awaitable<std::span<std::uint8_t>> Connection::receive_msg() {
 
 	// read the rest of the message
 	buffer = ba::buffer(buffer_.data() + sizeof(msg_size), msg_size - sizeof(msg_size));
-	co_await ba::async_read(socket_, buffer, ba::deferred);
+	co_await ba::async_read(socket_, buffer);
 	co_return std::span{buffer_.data(), msg_size};
 }
 
@@ -150,7 +149,7 @@ ba::awaitable<void> Connection::send(Message& msg) {
 		ba::const_buffer { msg.fbb.GetBufferPointer(), msg.fbb.GetSize() }
 	};
 
-	co_await ba::async_write(socket_, buffers, ba::deferred);
+	co_await ba::async_write(socket_, buffers);
 }
 
 // start full-duplex send/receive

--- a/src/libs/spark/src/Server.cpp
+++ b/src/libs/spark/src/Server.cpp
@@ -17,7 +17,6 @@
 #include <boost/asio/as_tuple.hpp>
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/connect.hpp>
-#include <boost/asio/deferred.hpp>
 #include <boost/asio/detached.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -56,7 +55,7 @@ ba::awaitable<void> Server::accept_connection() {
 	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
 
 	ba::ip::tcp::socket socket(ctx_);
-	auto [ec] = co_await acceptor_.async_accept(socket, boost::asio::as_tuple(ba::deferred));
+	auto [ec] = co_await acceptor_.async_accept(socket, boost::asio::as_tuple);
 
 	if(ec) {
 		co_return;
@@ -115,12 +114,10 @@ ba::awaitable<std::shared_ptr<RemotePeer>>
 Server::connect(std::string_view host, const std::uint16_t port) try {
 	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
 
-	auto results = co_await resolver_.async_resolve(
-		host, std::to_string(port), ba::deferred
-	);
+	auto results = co_await resolver_.async_resolve(host, std::to_string(port));
 
 	ba::ip::tcp::socket socket(ctx_);
-	co_await ba::async_connect(socket, results.begin(), results.end(), ba::deferred);
+	co_await ba::async_connect(socket, results.begin(), results.end());
 
 	const auto key = std::format("{}:{}", host, port);
 


### PR DESCRIPTION
GCC & MSVC optimisers weren't being quite as smart about this as hoped (Clang was fine). Split things up to help them out.