### PR TITLE
Preallocate gateway client connections

### DIFF
--- a/src/gateway/SessionManager.cpp
+++ b/src/gateway/SessionManager.cpp
@@ -11,11 +11,6 @@
 
 namespace ember::gateway {
 
-void SessionManager::insert(std::unique_ptr<ClientConnection> session) {
-	std::lock_guard guard(sessions_lock_);
-	sessions_.insert(std::move(session));
-}
-
 void SessionManager::stop(ClientConnection* session) {
 	std::lock_guard guard(sessions_lock_);
 

--- a/src/gateway/SessionManager.h
+++ b/src/gateway/SessionManager.h
@@ -75,7 +75,7 @@ public:
 		auto client = ClientConnPtr(
 			allocator_.allocate(std::forward<Args>(args)...), [&](auto ptr) {
 				allocator_.deallocate(ptr);
-			};
+			}
 		);
 
 		std::lock_guard guard(sessions_lock_);

--- a/src/gateway/SessionManager.h
+++ b/src/gateway/SessionManager.h
@@ -64,7 +64,7 @@ class SessionManager final {
 	};
 
 	SessionAllocator allocator_;
-	boost::unordered_flat_set<std::unique_ptr<ClientConnection>, Hasher, KeyEqual> sessions_;
+	boost::unordered_flat_set<ClientConnPtr, Hasher, KeyEqual> sessions_;
 	mutable std::mutex sessions_lock_;
 
 public:
@@ -72,7 +72,7 @@ public:
 
 	template<typename... Args>
 	void emplace(Args&&... args) {
-		auto client = std::unique_ptr<ClientConnection>(
+		auto client = ClientConnPtr(
 			allocator_.allocate(std::forward<Args>(args)...), [&](auto ptr) {
 				allocator_.deallocate(ptr);
 			};
@@ -82,7 +82,6 @@ public:
 		sessions_.emplace(std::move(client));
 	}
 
-	void insert(std::unique_ptr<ClientConnection> session);
 	void stop(ClientConnection* session);
 	void stop_all();
 	std::size_t count() const;

--- a/src/gateway/SessionManager.h
+++ b/src/gateway/SessionManager.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "ClientConnection.h"
+#include <spark/buffers/allocators/TLSBlockAllocator.h>
 #include <boost/unordered/unordered_flat_set.hpp>
 #include <memory>
 #include <mutex>
@@ -18,7 +19,20 @@ namespace ember::gateway {
 
 struct ConnectionStats;
 
+#ifndef PREALLOCATED_SESSIONS_PER_THREAD
+	#define PREALLOCATED_SESSIONS_PER_THREAD 32
+#endif
+
 class SessionManager final {
+	using SessionAllocator = spark::io::TLSBlockAllocator<
+		ClientConnection,
+		PREALLOCATED_SESSIONS_PER_THREAD,
+		spark::io::NoRefCounting,
+		spark::io::SafeEntrant
+	>;
+
+	using ClientConnPtr = std::unique_ptr<ClientConnection, std::function<void(ClientConnection*)>>;
+
 	struct Hasher {
 		using is_transparent = void;
 
@@ -26,7 +40,7 @@ class SessionManager final {
 			return std::hash<ClientConnection*>{}(p);
 		}
 
-		std::size_t operator()(const std::unique_ptr<ClientConnection>& p) const {
+		std::size_t operator()(const ClientConnPtr& p) const {
 			return std::hash<const ClientConnection*>{}(p.get()); 
 		}
 	};
@@ -44,11 +58,12 @@ class SessionManager final {
 			return p; 
 		}
 
-		static const ClientConnection* to_ptr(const std::unique_ptr<ClientConnection>& p) {
+		static const ClientConnection* to_ptr(const ClientConnPtr& p) {
 			return p.get(); 
 		}
 	};
 
+	SessionAllocator allocator_;
 	boost::unordered_flat_set<std::unique_ptr<ClientConnection>, Hasher, KeyEqual> sessions_;
 	mutable std::mutex sessions_lock_;
 
@@ -57,7 +72,12 @@ public:
 
 	template<typename... Args>
 	void emplace(Args&&... args) {
-		auto client = std::make_unique<ClientConnection>(std::forward<Args>(args)...);
+		auto client = std::unique_ptr<ClientConnection>(
+			allocator_.allocate(std::forward<Args>(args)...), [&](auto ptr) {
+				allocator_.deallocate(ptr);
+			};
+		);
+
 		std::lock_guard guard(sessions_lock_);
 		sessions_.emplace(std::move(client));
 	}

--- a/src/libs/spark/include/spark/buffers/allocators/BlockAllocator.h
+++ b/src/libs/spark/include/spark/buffers/allocators/BlockAllocator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ember
+ * Copyright (c) 2024 - 2026 Ember
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -181,7 +181,7 @@ public:
 			--new_active_count;
 #endif
 			t->~_ty();
-			delete block;
+			operator delete(block);
 		} else {
 #ifdef EMBER_DEBUG_ALLOCATORS
 			--storage_active_count;


### PR DESCRIPTION
Use a small default number, can override with `PREALLOCATED_SESSIONS_PER_THREAD`.