### PR TITLE
Split command tokens into string_views rather than string

### DIFF
--- a/src/libs/shared/shared/commands/Command.h
+++ b/src/libs/shared/shared/commands/Command.h
@@ -12,6 +12,7 @@
 #include "Arguments.h"
 #include "ArgumentType.h"
 #include "Result.h"
+#include <shared/utility/StringHash.h>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -26,7 +27,7 @@ namespace ember::commands {
 class Command;
 
 using CommandHandler = std::function<void(const Arguments&)>;
-using CommandMap = std::unordered_map<std::string, std::shared_ptr<Command>>;
+using CommandMap = std::unordered_map<std::string, std::shared_ptr<Command>, StringHash, std::equal_to<>>;
 
 class Command : public std::enable_shared_from_this<Command> {
 	mutable std::mutex mutex_;

--- a/src/libs/shared/shared/commands/Registry.cpp
+++ b/src/libs/shared/shared/commands/Registry.cpp
@@ -24,8 +24,8 @@ void Registry::register_command(std::shared_ptr<Command> command) {
 	root_->subcommand(std::move(command));
 }
 
-std::vector<std::string> Registry::parse_input(std::string_view input) const {
-	std::vector<std::string> tokens;
+std::vector<std::string_view> Registry::parse_input(std::string_view input) const {
+	std::vector<std::string_view> tokens;
 	std::string str(input);
 
 	try {
@@ -44,7 +44,7 @@ std::vector<std::string> Registry::parse_input(std::string_view input) const {
 
 // this is really inefficient due to the registry copies (must be copied from subcommands for safety)
 // but it's not even remotely performance sensitive, so it'll do
-auto Registry::search(std::span<const std::string> tokens) const -> SearchResult {
+auto Registry::search(std::span<const std::string_view> tokens) const -> SearchResult {
 	// we need go as deep as possible into the subcommand chain
 	SearchResult search;
 	auto registry = root_->subcommands();
@@ -92,7 +92,7 @@ std::string Registry::longest_prefix(std::span<const Suggestions::Record> matche
 	return prefix;
 }
 
-Suggestions Registry::autocomplete_recurse(const CommandMap& commands, std::span<const std::string> tokens) const {
+Suggestions Registry::autocomplete_recurse(const CommandMap& commands, std::span<const std::string_view> tokens) const {
 	Suggestions result;
 
 	if(tokens.empty()) {

--- a/src/libs/shared/shared/commands/Registry.h
+++ b/src/libs/shared/shared/commands/Registry.h
@@ -35,7 +35,7 @@ public:
 private:
 	std::shared_ptr<Command> root_;
 
-	Suggestions autocomplete_recurse(const CommandMap& commands, std::span<const std::string> tokens) const;
+	Suggestions autocomplete_recurse(const CommandMap& commands, std::span<const std::string_view> tokens) const;
 	std::string longest_prefix(std::span<const Suggestions::Record> matches) const;
 
 public:
@@ -44,10 +44,10 @@ public:
 	std::shared_ptr<Command> register_command(std::string name);
 	void register_command(std::shared_ptr<Command> command);
 
-	std::vector<std::string> parse_input(std::string_view input) const;
+	std::vector<std::string_view> parse_input(std::string_view input) const;
 	Suggestions autocomplete(std::string_view query) const;
 
-	SearchResult search(std::span<const std::string> tokens) const;
+	SearchResult search(std::span<const std::string_view> tokens) const;
 	bool unregister(const std::string& name);
 	std::shared_ptr<Command> root() const;
 };

--- a/src/libs/shared/shared/commands/Utility.h
+++ b/src/libs/shared/shared/commands/Utility.h
@@ -16,7 +16,7 @@ namespace ember::commands {
 
 constexpr auto approx_cmd_len = 10u;
 
-inline std::string path_fragment(std::span<const std::string> tokens, std::size_t depth) {
+inline std::string path_fragment(std::span<const std::string_view> tokens, std::size_t depth) {
 	if(tokens.size() < depth) {
 		return {};
 	}

--- a/src/libs/shared/shared/utility/StringHash.h
+++ b/src/libs/shared/shared/utility/StringHash.h
@@ -1,10 +1,10 @@
 /*
-* Copyright (c) 2024 Ember
-*
-* This Source Code Form is subject to the terms of the Mozilla Public
-* License, v. 2.0. If a copy of the MPL was not distributed with this
-* file, You can obtain one at http://mozilla.org/MPL/2.0/.
-*/
+ * Copyright (c) 2024 - 2026 Ember
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 
 #pragma once
 


### PR DESCRIPTION
Previously couldn't do this due to using istringstream, now ditched