### PR TITLE
Remove logger from ports, clean logging callbacks up

### DIFF
--- a/src/account/CMakeLists.txt
+++ b/src/account/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_HDR
     Sessions.h
     AccountHandler.h
     Service.h
+    LoggingCallbacks.h
 )
 
 set(LIBRARY_SRC

--- a/src/account/LoggingCallbacks.h
+++ b/src/account/LoggingCallbacks.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Ember
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <logger/Logger.h>
+#include <conpool/LogSeverity.h>
+#include <string_view>
+
+namespace ember {
+
+inline void pool_log_callback(connection_pool::Severity severity, std::string_view message, log::Logger& logger) {
+	constexpr std::string_view fmt = "[pool] {}";
+
+	switch(severity) {
+		case connection_pool::Severity::debug:
+			LOG_DEBUG_ASYNC(logger, fmt, message);
+			break;
+		case connection_pool::Severity::info:
+			LOG_INFO_ASYNC(logger, fmt, message);
+			break;
+		case connection_pool::Severity::warn:
+			LOG_WARN_ASYNC(logger, fmt, message);
+			break;
+		case connection_pool::Severity::error:
+			LOG_ERROR_ASYNC(logger, fmt, message);
+			break;
+		case connection_pool::Severity::fatal:
+			LOG_FATAL_ASYNC(logger, fmt, message);
+			break;
+		default:
+			LOG_ERROR_ASYNC(logger, "Unhandled connection pool log callback severity");
+			LOG_ERROR_ASYNC(logger, fmt, message);
+	}
+}
+
+} // ember

--- a/src/account/Service.cpp
+++ b/src/account/Service.cpp
@@ -11,6 +11,7 @@
 #include "AccountHandler.h"
 #include "FilterTypes.h"
 #include "Sessions.h"
+#include "LoggingCallbacks.h"
 #include <logger/Logger.h>
 #include <conpool/ConnectionPool.h>
 #include <conpool/Policies.h>
@@ -30,11 +31,8 @@
 #include <cstdint>
 
 namespace po = boost::program_options;
-namespace ep = ember::connection_pool;
 
 namespace ember::account {
-
-void pool_log_callback(ep::Severity, std::string_view message, log::Logger& logger);
 
 /*
  * Starts Asio worker threads, blocking until the launch thread exits
@@ -83,7 +81,7 @@ void Service::launch(const po::variables_map& args, boost::asio::io_context& ser
 
 	LOG_INFO_SYNC(logger, "Initialising database connection pool...");
 
-	ep::Pool<decltype(driver), ep::CheckinClean, ep::ExponentialGrowth> pool(
+	connection_pool::Pool<decltype(driver), connection_pool::CheckinClean, connection_pool::ExponentialGrowth> pool(
 		driver, min_conns, max_conns, 30s
 	);
 
@@ -160,29 +158,6 @@ po::options_description Service::options() {
 		("monitor.interface", po::value<std::string>()->required())
 		("monitor.port", po::value<std::uint16_t>()->required());
 	return opts;
-}
-
-void pool_log_callback(ep::Severity severity, std::string_view message, log::Logger& logger) {
-	switch(severity) {
-		case ep::Severity::debug:
-			LOG_DEBUG(logger) << message << LOG_ASYNC;
-			break;
-		case ep::Severity::info:
-			LOG_INFO(logger) << message << LOG_ASYNC;
-			break;
-		case ep::Severity::warn:
-			LOG_WARN(logger) << message << LOG_ASYNC;
-			break;
-		case ep::Severity::error:
-			LOG_ERROR(logger) << message << LOG_ASYNC;
-			break;
-		case ep::Severity::fatal:
-			LOG_FATAL(logger) << message << LOG_ASYNC;
-			break;
-		default:
-			LOG_ERROR_ASYNC(logger, "Unhandled pool log callback severity");
-			LOG_ERROR(logger) << message << LOG_ASYNC;
-	}	
 }
 
 } // account, ember

--- a/src/character/CMakeLists.txt
+++ b/src/character/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LIBRARY_HDR
     CharacterService.h
     Service.h
     Config.h
+    LoggingCallbacks.h
     )
 
 set(LIBRARY_SRC

--- a/src/character/LoggingCallbacks.h
+++ b/src/character/LoggingCallbacks.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Ember
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <logger/Logger.h>
+#include <conpool/LogSeverity.h>
+#include <string_view>
+
+namespace ember {
+
+inline void pool_log_callback(connection_pool::Severity severity, std::string_view message, log::Logger& logger) {
+	constexpr std::string_view fmt = "[pool] {}";
+
+	switch(severity) {
+		case connection_pool::Severity::debug:
+			LOG_DEBUG_ASYNC(logger, fmt, message);
+			break;
+		case connection_pool::Severity::info:
+			LOG_INFO_ASYNC(logger, fmt, message);
+			break;
+		case connection_pool::Severity::warn:
+			LOG_WARN_ASYNC(logger, fmt, message);
+			break;
+		case connection_pool::Severity::error:
+			LOG_ERROR_ASYNC(logger, fmt, message);
+			break;
+		case connection_pool::Severity::fatal:
+			LOG_FATAL_ASYNC(logger, fmt, message);
+			break;
+		default:
+			LOG_ERROR_ASYNC(logger, "Unhandled connection pool log callback severity");
+			LOG_ERROR_ASYNC(logger, fmt, message);
+	}
+}
+
+} // ember

--- a/src/character/Service.cpp
+++ b/src/character/Service.cpp
@@ -10,6 +10,7 @@
 #include "FilterTypes.h"
 #include "CharacterHandler.h"
 #include "CharacterService.h"
+#include "LoggingCallbacks.h"
 #include <dbcreader/Reader.h>
 #include <conpool/ConnectionPool.h>
 #include <conpool/Policies.h>
@@ -27,12 +28,9 @@
 #include <cstdint>
 
 namespace po = boost::program_options;
-namespace ep = ember::connection_pool;
 using namespace std::chrono_literals;
 
 namespace ember::character {
-
-void pool_log_callback(ep::Severity, std::string_view message, log::Logger& logger);
 
 /*
  * Starts Asio worker threads, blocking until the launch thread exits
@@ -124,7 +122,10 @@ void Service::launch(const po::variables_map& args, boost::asio::io_context& ser
 	}
 
 	LOG_INFO_SYNC(logger, "Initialising database connection pool...");
-	ep::Pool<decltype(driver), ep::CheckinClean, ep::ExponentialGrowth> pool(driver, min_conns, max_conns, 30s);
+
+	connection_pool::Pool<decltype(driver), connection_pool::CheckinClean, connection_pool::ExponentialGrowth> pool(
+		driver, min_conns, max_conns, 30s
+	);
 	
 	pool.logging_callback([&](auto severity, auto message) {
 		pool_log_callback(severity, message, logger);
@@ -162,31 +163,6 @@ void Service::launch(const po::variables_map& args, boost::asio::io_context& ser
 	LOG_INFO_SYNC(logger, "{} shutting down...", APP_NAME);
 } catch(...) {
 	eptr = std::current_exception();
-}
-
-void pool_log_callback(ep::Severity severity, std::string_view message, log::Logger& logger) {
-#undef ERROR // Windows moment
-
-	switch(severity) {
-		case ep::Severity::debug:
-			LOG_DEBUG(logger) << message << LOG_ASYNC;
-			break;
-		case ep::Severity::info:
-			LOG_INFO(logger) << message << LOG_ASYNC;
-			break;
-		case ep::Severity::warn:
-			LOG_WARN(logger) << message << LOG_ASYNC;
-			break;
-		case ep::Severity::error:
-			LOG_ERROR(logger) << message << LOG_ASYNC;
-			break;
-		case ep::Severity::fatal:
-			LOG_FATAL(logger) << message << LOG_ASYNC;
-			break;
-		default:
-			LOG_ERROR_ASYNC(logger, "Unhandled pool log callback severity");
-			LOG_ERROR(logger) << message << LOG_ASYNC;
-	}
 }
 
 po::options_description Service::options() {

--- a/src/gateway/CMakeLists.txt
+++ b/src/gateway/CMakeLists.txt
@@ -54,6 +54,7 @@ set(LIBRARY_HDR
     packet_log/FBSink.h
     packet_log/LogSink.h
     Service.h
+    LoggingCallbacks.h
 )
 
 set(LIBRARY_SRC

--- a/src/gateway/LoggingCallbacks.h
+++ b/src/gateway/LoggingCallbacks.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Ember
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <logger/Logger.h>
+#include <stun/Logging.h>
+#include <conpool/LogSeverity.h>
+#include <ports/LogSeverity.h>
+#include <string_view>
+
+namespace ember {
+
+inline void forward_log_callback(ports::Severity severity, const std::string_view message, log::Logger& logger) {
+	constexpr std::string_view fmt = "[ports] {}";
+
+	switch(severity) {
+		case ports::Severity::debug:
+			LOG_DEBUG_ASYNC(logger, fmt, message);
+			break;
+		case ports::Severity::info:
+			LOG_INFO_ASYNC(logger, fmt, message);
+			break;
+		case ports::Severity::warn:
+			LOG_WARN_ASYNC(logger, fmt, message);
+			break;
+		case ports::Severity::error:
+			LOG_ERROR_ASYNC(logger, fmt, message);
+			break;
+		case ports::Severity::fatal:
+			LOG_FATAL_ASYNC(logger, fmt, message);
+			break;
+		default:
+			LOG_ERROR_ASYNC(logger, "Unhandled port forward log callback severity");
+			LOG_ERROR_ASYNC(logger, fmt, message);
+	}
+}
+
+inline static void stun_log_callback(stun::Severity severity, stun::Error reason, log::Logger& logger) {
+	constexpr std::string_view fmt = "[stun] {}";
+	const std::string_view reason_str = to_string(reason);
+
+	switch(severity) {
+		case stun::Severity::trace:
+			LOG_TRACE_SYNC(logger, fmt, reason_str);
+			break;
+		case stun::Severity::debug:
+			LOG_DEBUG_SYNC(logger, fmt, reason_str);
+			break;
+		case stun::Severity::info:
+			LOG_INFO_SYNC(logger, fmt, reason_str);
+			break;
+		case stun::Severity::warn:
+			LOG_WARN_SYNC(logger, fmt, reason_str);
+			break;
+		case stun::Severity::error:
+			LOG_ERROR_SYNC(logger, fmt, reason_str);
+			break;
+		case stun::Severity::fatal:
+			LOG_FATAL_SYNC(logger, fmt, reason_str);
+			break;
+		default:
+			LOG_ERROR_ASYNC(logger, "Unhandled STUN log callback severity");
+			LOG_ERROR_SYNC(logger, fmt, reason_str);
+	}
+}
+
+inline void pool_log_callback(connection_pool::Severity severity, std::string_view message, log::Logger& logger) {
+	constexpr std::string_view fmt = "[pool] {}";
+
+	switch(severity) {
+		case connection_pool::Severity::debug:
+			LOG_DEBUG_ASYNC(logger, fmt, message);
+			break;
+		case connection_pool::Severity::info:
+			LOG_INFO_ASYNC(logger, fmt, message);
+			break;
+		case connection_pool::Severity::warn:
+			LOG_WARN_ASYNC(logger, fmt, message);
+			break;
+		case connection_pool::Severity::error:
+			LOG_ERROR_ASYNC(logger, fmt, message);
+			break;
+		case connection_pool::Severity::fatal:
+			LOG_FATAL_ASYNC(logger, fmt, message);
+			break;
+		default:
+			LOG_ERROR_ASYNC(logger, "Unhandled connection pool log callback severity");
+			LOG_ERROR_ASYNC(logger, fmt, message);
+	}
+}
+
+} // ember

--- a/src/gateway/Service.cpp
+++ b/src/gateway/Service.cpp
@@ -7,15 +7,16 @@
  */
 
 #include "Service.h"
-#include "Config.h"
-#include "Locator.h"
-#include "FilterTypes.h"
-#include "RealmQueue.h"
 #include "AccountClient.h"
-#include "EventDispatcher.h"
 #include "CharacterClient.h"
-#include "RealmService.h"
+#include "Config.h"
+#include "EventDispatcher.h"
+#include "FilterTypes.h"
+#include "Locator.h"
+#include "LoggingCallbacks.h"
 #include "NetworkListener.h"
+#include "RealmQueue.h"
+#include "RealmService.h"
 #include <conpool/ConnectionPool.h>
 #include <conpool/Policies.h>
 #include <conpool/drivers/AutoSelect.h>
@@ -58,12 +59,10 @@
 using namespace std::chrono_literals;
 
 namespace po = boost::program_options;
-namespace ep = ember::connection_pool;
 
 namespace ember::gateway {
 
 std::optional<Realm> load_realm(const po::variables_map& args, log::Logger& logger);
-void pool_log_callback(ep::Severity, std::string_view message, log::Logger& logger);
 std::string_view category_name(const Realm& realm, const dbc::Store<dbc::Cfg_Categories>& dbc);
 void print_lib_versions(log::Logger& logger);
 
@@ -130,8 +129,8 @@ void Service::launch(const po::variables_map& args, ServicePool& service_pool) t
 	std::future<stun::MappedResult> stun_res;
 
 	if(stun_enabled) {
-		stun.log_callback([&](const stun::Verbosity verbosity, const stun::Error reason) {
-			stun_log_callback(verbosity, reason, logger);
+		stun.log_callback([&](const stun::Severity severity, const stun::Error reason) {
+			stun_log_callback(severity, reason, logger);
 		});
 
 		LOG_INFO_SYNC(logger, "Starting STUN query...");
@@ -227,7 +226,9 @@ void Service::launch(const po::variables_map& args, ServicePool& service_pool) t
 				const auto& gateway = args["forward.gateway"].as<std::string>();
 
 				forward = std::make_unique<ports::Forward>(
-					logger, service, mode, interface, gateway, port
+					service, mode, interface, gateway, port, [&](auto severity, auto message) {
+						forward_log_callback(severity, message, logger);
+					}
 				);
 			}
 		} else if(!result && forward_enabled) {
@@ -315,7 +316,10 @@ std::optional<Realm> load_realm(const po::variables_map& args, log::Logger& logg
 	auto driver(drivers::init_db_driver(db_config_path, "login"));
 
 	LOG_INFO_SYNC(logger, "Initialising database connection pool...");
-	ep::Pool<decltype(driver), ep::CheckinClean, ep::ExponentialGrowth> pool(driver, 1, 1, 30s);
+
+	connection_pool::Pool<decltype(driver), connection_pool::CheckinClean, connection_pool::ExponentialGrowth> pool(
+		driver, 1, 1, 30s
+	);
 	
 	pool.logging_callback([&](auto severity, auto message) {
 		pool_log_callback(severity, message, logger);
@@ -326,29 +330,6 @@ std::optional<Realm> load_realm(const po::variables_map& args, log::Logger& logg
 
 	LOG_INFO_SYNC(logger, "Retrieving realm information...");
 	return realm_dao.get_realm(args["realm.id"].as<unsigned int>());
-}
-
-void pool_log_callback(ep::Severity severity, std::string_view message, log::Logger& logger) {
-	switch(severity) {
-		case ep::Severity::debug:
-			LOG_DEBUG(logger) << message << LOG_ASYNC;
-			break;
-		case ep::Severity::info:
-			LOG_INFO(logger) << message << LOG_ASYNC;
-			break;
-		case ep::Severity::warn:
-			LOG_WARN(logger) << message << LOG_ASYNC;
-			break;
-		case ep::Severity::error:
-			LOG_ERROR(logger) << message << LOG_ASYNC;
-			break;
-		case ep::Severity::fatal:
-			LOG_FATAL(logger) << message << LOG_ASYNC;
-			break;
-		default:
-			LOG_ERROR_ASYNC(logger, "Unhandled pool log callback severity");
-			LOG_ERROR(logger) << message << LOG_ASYNC;
-	}
 }
 
 void print_lib_versions(log::Logger& logger) {

--- a/src/libs/logger/include/logger/HelperMacros.h
+++ b/src/libs/logger/include/logger/HelperMacros.h
@@ -55,8 +55,8 @@ inline auto& log_deref(auto* x) { return *x; }
 
 #if !defined(NO_LOGGING) && !defined(NO_ERROR_LOGGING)
 	#define LOG_ERROR(logger) \
-		if(logger->severity() <= ember::log::Severity::ERROR_) \
-			log_deref(logger) << ember::log::Severity::ERROR_
+		if(logger->severity() <= ember::log::Severity::error) \
+			log_deref(logger) << ember::log::Severity::error
 #else
 	#define LOG_ERROR(logger) \
 		if(false) \
@@ -136,8 +136,8 @@ inline auto& log_deref(auto* x) { return *x; }
 
 #if !defined(NO_LOGGING) && !defined(NO_ERROR_LOGGING)
 	#define LOG_ERROR_FILTER(logger, type) \
-		if(logger->severity() <= ember::log::Severity::ERROR_ && !(logger->filter() & type)) \
-			log_deref(logger) << ember::log::Severity::ERROR_ << ember::log::Filter(type)
+		if(logger->severity() <= ember::log::Severity::error && !(logger->filter() & type)) \
+			log_deref(logger) << ember::log::Severity::error << ember::log::Filter(type)
 #else
 	#define LOG_ERROR_FILTER(logger, type) \
 		if(false) \
@@ -261,8 +261,8 @@ inline auto& log_deref(auto* x) { return *x; }
 
 #if !defined(NO_LOGGING) && !defined(NO_ERROR_LOGGING)
 	#define LOG_ERROR_ASYNC(logger, fmt_str, ...) \
-		if(logger->severity() <= ember::log::Severity::ERROR_) \
-			logger->fmt_write<true>(ember::log::Severity::ERROR_, fmt_str __VA_OPT__(,) __VA_ARGS__);
+		if(logger->severity() <= ember::log::Severity::error) \
+			logger->fmt_write<true>(ember::log::Severity::error, fmt_str __VA_OPT__(,) __VA_ARGS__);
 #else
 	#define LOG_ERROR_ASYNC(logger, fmt_str, ...) \
 		if(false);
@@ -333,8 +333,8 @@ inline auto& log_deref(auto* x) { return *x; }
 
 #if !defined(NO_LOGGING) && !defined(NO_ERROR_LOGGING)
 	#define LOG_ERROR_SYNC(logger, fmt_str, ...) \
-		if(logger->severity() <= ember::log::Severity::ERROR_) \
-			logger->fmt_write<false>(ember::log::Severity::ERROR_, fmt_str __VA_OPT__(,) __VA_ARGS__);
+		if(logger->severity() <= ember::log::Severity::error) \
+			logger->fmt_write<false>(ember::log::Severity::error, fmt_str __VA_OPT__(,) __VA_ARGS__);
 #else
 	#define LOG_ERROR_SYNC(logger, fmt_str, ...) \
 		if(false);

--- a/src/libs/logger/include/logger/Severity.h
+++ b/src/libs/logger/include/logger/Severity.h
@@ -18,7 +18,7 @@ enum class Severity {
 	debug,
 	info,
 	warn,
-	ERROR_,
+	error,
 	fatal,
 	console,
 	console_error,

--- a/src/libs/logger/src/ConsoleSink.cpp
+++ b/src/libs/logger/src/ConsoleSink.cpp
@@ -123,7 +123,7 @@ utility::Colour ConsoleSink::severity_colour(Severity severity) {
 	switch(severity) {
 		case Severity::fatal:
 			[[fallthrough]];
-		case Severity::ERROR_:
+		case Severity::error:
 			[[fallthrough]];
 		case Severity::warn:
 			return utility::Colour::light_red;

--- a/src/libs/logger/src/SyslogSink.cpp
+++ b/src/libs/logger/src/SyslogSink.cpp
@@ -75,7 +75,7 @@ auto SyslogSink::impl::severity_map(Severity severity) -> SyslogSeverity {
 	switch(severity) {
 		case Severity::fatal:
 			return SyslogSink::impl::SyslogSeverity::syslog_emergency;
-		case Severity::ERROR_:
+		case Severity::error:
 			return SyslogSink::impl::SyslogSeverity::syslog_error;
 		case Severity::warn:
 			return SyslogSink::impl::SyslogSeverity::syslog_warning;

--- a/src/libs/logger/src/Utility.cpp
+++ b/src/libs/logger/src/Utility.cpp
@@ -69,7 +69,7 @@ std::string_view severity_string(Severity severity) {
 			return "[warning] ";
 		case Severity::info:
 			return "[info] ";
-		case Severity::ERROR_:
+		case Severity::error:
 			return "[error] ";
 		case Severity::fatal:
 			return "[fatal] ";
@@ -94,7 +94,7 @@ Severity severity_string(const std::string_view severity) {
 	} else if(severity == "warning") {
 		return Severity::warn;
 	} else if(severity == "error") {
-		return Severity::ERROR_;
+		return Severity::error;
 	} else if(severity == "fatal") {
 		return Severity::fatal;
 	} else if(severity == "console") {
@@ -135,7 +135,7 @@ std::ostream& operator<<(std::ostream& stream, const Severity& severity) {
 		case Severity::info:
 			stream << "info";
 			break;
-		case Severity::ERROR_:
+		case Severity::error:
 			stream << "error";
 			break;
 		case Severity::fatal:

--- a/src/libs/logger/src/win32/CommandSink.cpp
+++ b/src/libs/logger/src/win32/CommandSink.cpp
@@ -165,7 +165,7 @@ utility::Colour CommandSink::severity_colour(Severity severity) {
 			return utility::Colour::white_on_red_bg;
 		case Severity::fatal:
 			[[fallthrough]];
-		case Severity::ERROR_:
+		case Severity::error:
 			[[fallthrough]];
 		case Severity::warn:
 			return utility::Colour::light_red;

--- a/src/libs/ports/CMakeLists.txt
+++ b/src/libs/ports/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(${LIBRARY_NAME} STATIC
     src/upnp/XMLParser.cpp
     src/upnp/Utility.cpp
     src/upnp/SCPDXMLParser.cpp
+    include/ports/LogSeverity.h
     include/ports/Protocol.h
     include/ports/Forward.h
 	include/ports/Utility.h

--- a/src/libs/ports/include/ports/Forward.h
+++ b/src/libs/ports/include/ports/Forward.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <logger/Logger.h>
+#include <ports/LogSeverity.h>
 #include <ports/pcp/Client.h>
 #include <ports/pcp/Daemon.h>
 #include <ports/upnp/SSDP.h>
@@ -16,6 +16,7 @@
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/deadline_timer.hpp>
 #include <atomic>
+#include <functional>
 #include <semaphore>
 #include <memory>
 #include <string>
@@ -37,6 +38,8 @@ class Forward final {
 	static constexpr auto timeout_interval = 10s;
 
 public:
+	using LogCallback = std::function<void(Severity, const std::string_view)>;
+
 	enum class Method {
 		upnp,
 		pmp_pcp,
@@ -44,7 +47,6 @@ public:
 	};
 
 	boost::asio::io_context& ctx_;
-	log::Logger& logger_;
 	std::uint16_t port_;
 	std::atomic_bool mapping_active_;
 	std::unique_ptr<ports::Client> client_;
@@ -53,8 +55,12 @@ public:
 	std::shared_ptr<ports::upnp::IGDevice> upnp_device_;
 	boost::asio::steady_timer timer_;
 	std::binary_semaphore shutdown_wait_;
+	LogCallback log_cb_;
 
-	std::string_view error_string(const Error& error);
+	template<typename ... Args>
+	void log(Severity severity, const std::format_string<Args...> fmt, Args&& ...args) const;
+
+	std::string_view error_string(const Error& error) const;
 	void begin_forwarding(Method Method, const std::string& iface, const std::string& gateway, std::uint16_t port);
 	void try_pmp(const std::string& iface, const std::string& gateway, std::uint16_t port);
 	void start_upnp(const std::string& iface, std::uint16_t port);
@@ -65,8 +71,8 @@ public:
 	void unmap_pmp();
 
 public:
-	Forward(log::Logger& logger, boost::asio::io_context& ctx, Method method,
-	        const std::string& iface, const std::string& gateway, std::uint16_t port);
+	Forward(boost::asio::io_context& ctx, Method method, const std::string& iface,
+			const std::string& gateway, std::uint16_t port, LogCallback cb = {});
 
 	~Forward();
 	void unmap();

--- a/src/libs/ports/include/ports/LogSeverity.h
+++ b/src/libs/ports/include/ports/LogSeverity.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Ember
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+namespace ember::ports {
+
+enum class Severity {
+	trace,
+	debug,
+	info,
+	warn,
+	error,
+	fatal
+};
+
+} // ports, ember

--- a/src/libs/ports/src/Forward.cpp
+++ b/src/libs/ports/src/Forward.cpp
@@ -8,17 +8,18 @@
 
 #include <ports/Forward.h>
 #include <boost/asio/post.hpp>
+#include <format>
 
 namespace ember::ports {
 
-Forward::Forward(log::Logger& logger, boost::asio::io_context& ctx, Method method,
-                 const std::string& iface, const std::string& gateway, std::uint16_t port)
+Forward::Forward(boost::asio::io_context& ctx, Method method, const std::string& iface,
+                 const std::string& gateway, std::uint16_t port, LogCallback cb)
 	: ctx_(ctx),
-	  logger_(logger),
 	  port_(port),
 	  mapping_active_(false),
 	  timer_(ctx),
-	  shutdown_wait_(0) {
+	  shutdown_wait_(0),
+	  log_cb_(cb) {
 	begin_forwarding(method, iface, gateway, port);
 }
 
@@ -26,12 +27,26 @@ Forward::~Forward() {
 	unmap();
 }
 
+template<typename ...Args>
+void Forward::log(Severity severity, const std::format_string<Args...> fmt, Args&& ...args) const {
+	if(!log_cb_) {
+		return;
+	}
+
+	const auto formatted = std::format(fmt, std::forward<Args>(args)...);
+	log_cb_(severity, formatted);
+}
+
 void Forward::start_upnp(const std::string& iface, std::uint16_t port) {
 	ssdp_ = std::make_unique<ports::upnp::SSDP>(iface, ctx_);
 
 	ssdp_->locate_gateways([&, port](ports::upnp::LocateResult result) {
 		if(!result) {
-			LOG_ERROR_ASYNC(logger_, "UPnP gateway search failed with error code {}", result.error().value());
+			log(
+				Severity::error,
+				"UPnP gateway search failed with error code {}", result.error().value()
+			);
+
 			return true;
 		}
 
@@ -44,10 +59,10 @@ void Forward::start_upnp(const std::string& iface, std::uint16_t port) {
 
 		result->device->add_port_mapping(map, [&](ports::upnp::ErrorCode ec) {
 			if(!ec) {
-				LOG_INFO_ASYNC(logger_, "[UPnP] Port {} successfully forwarded", port);
+				log(Severity::info, "[UPnP] Port {} successfully forwarded", port);
 				mapping_active_ = true;
 			} else {
-				LOG_ERROR_ASYNC(logger_, "[UPnP] Port forwarding failed, error {}", ec.value());
+				log(Severity::error, "[UPnP] Port forwarding failed, error {}", ec.value());
 			}
 
 		});
@@ -72,23 +87,35 @@ void Forward::start_pmp(const std::string& iface, const std::string& gateway, st
 	
 		switch(event) {
 			case ports::Daemon::Event::added_mapping:
-				LOG_DEBUG_ASYNC(logger_, "[NATPMP/PCP][Daemon] {}:{} -> {} forwarded for {} seconds",
-								v6.to_string(), result.external_port, result.internal_port, result.lifetime);
+				log(
+					Severity::debug,
+					"[NATPMP/PCP][Daemon] {}:{} -> {} forwarded for {} seconds",
+					v6.to_string(), result.external_port, result.internal_port, result.lifetime
+				);
 				break;
 			case ports::Daemon::Event::failed_mapping:
-				LOG_DEBUG_ASYNC(logger_, "[NATPMP/PCP][Daemon] Port forwarding attempt failed, will retry...",
-								v6.to_string(), result.external_port, result.internal_port, result.lifetime);
+				log(Severity::debug,
+					"[NATPMP / PCP][Daemon] Port forwarding attempt failed, will retry...",
+					v6.to_string(), result.external_port, result.internal_port, result.lifetime
+				);
 				break;
 			case ports::Daemon::Event::renewed_mapping:
-				LOG_DEBUG_ASYNC(logger_, "[NATPMP/PCP] [Daemon] Port {} forwarding renewed for {} seconds",
-					            result.external_port, result.lifetime);
+				log(Severity::debug,
+					"[NATPMP/PCP] [Daemon] Port {} forwarding renewed for {} seconds",
+					result.external_port, result.lifetime
+				);
 				break;
 			case ports::Daemon::Event::failed_to_renew:
-				LOG_WARN_ASYNC(logger_, "[NATPMP/PCP] [Daemon] Port forwarding renewal failure, will retry...");
+				log(
+					Severity::warn,
+					"[NATPMP/PCP] [Daemon] Port forwarding renewal failure, will retry..."
+				);
 				break;
 			case ports::Daemon::Event::mapping_expired:
-				LOG_WARN_ASYNC(logger_, "[NATPMP/PCP] [Daemon] Port forwarding expired, service may be unavailable"
-					                    "to outside hosts, remapping will be attempted");
+				log(Severity::warn,
+					"[NATPMP/PCP] [Daemon] Port forwarding expired, service may be unavailable"
+					"to outside hosts, remapping will be attempted"
+				);
 				break;
 		}
 	});
@@ -97,21 +124,25 @@ void Forward::start_pmp(const std::string& iface, const std::string& gateway, st
 		if(result) {
 			const auto v6 = boost::asio::ip::address_v6(result->external_ip);
 
-			LOG_INFO_ASYNC(logger_, "[NATPMP/PCP] {}:{} -> {} forwarded for {} seconds (requested {} seconds)",
-							v6.to_string(),
-				            result->external_port,
-				            result->internal_port,
-				            result->lifetime,
-							request.lifetime);
+			log(Severity::info,
+				"[NATPMP/PCP] {}:{} -> {} forwarded for {} seconds (requested {} seconds)",
+				v6.to_string(),
+			    result->external_port,
+			    result->internal_port,
+			    result->lifetime,
+				request.lifetime
+			);
 			mapping_active_ = true;
 		} else {
-			LOG_ERROR_ASYNC(logger_, R"([NATPMP/PCP] Port forwarding failed, error "{}")", error_string(result.error()));
+			log(Severity::error,
+				R"([NATPMP/PCP] Port forwarding failed, error "{}")", error_string(result.error())
+			);
 			mapping_active_ = false; // mapping can succeed and later fail when refreshed
 		}
 	});
 }
 
-std::string_view Forward::error_string(const Error& error) {
+std::string_view Forward::error_string(const Error& error) const {
 	if(error.code == ErrorCode::natpmp_code) {
 		return to_string(error.natpmp_code);
 	} else if(error.code == ErrorCode::pcp_code) {
@@ -133,9 +164,13 @@ void Forward::unmap_upnp() {
 
 	upnp_device_->delete_port_mapping(map, [&](ports::upnp::ErrorCode ec) {
 		if(!ec) {
-			LOG_INFO_ASYNC(logger_, "[UPnP] Successfully unmapped forwarded port {}", port_);
+			log(Severity::info,
+				"[UPnP] Successfully unmapped forwarded port {}", port_
+			);
 		} else {
-			LOG_ERROR_ASYNC(logger_, "[UPnP] Failed to unmap forwarded port {}, error ", ec.value());
+			log(Severity::info,
+				"[UPnP] Failed to unmap forwarded port {}, error ", ec.value()
+			);
 		}
 
 		shutdown_wait_.release();
@@ -147,9 +182,13 @@ void Forward::unmap_pmp() {
 
 	daemon_->delete_mapping(port_, ports::Protocol::tcp, [&](const ports::Result& result) {
 		if(result) {
-			LOG_INFO_ASYNC(logger_, "[NATPMP/PCP] Successfully unmapped forwarded port", port_);
+			log(Severity::info,
+				"[NATPMP/PCP] Successfully unmapped forwarded port", port_
+			);
 		} else {
-			LOG_ERROR_ASYNC(logger_, "[NATPMP/PCP] Failed to unmap forwarded port, error {}", result.error().code);
+			log(Severity::error,
+				"[NATPMP/PCP] Failed to unmap forwarded port, error {}", result.error().code
+			);
 		}
 
 		shutdown_wait_.release();
@@ -169,13 +208,15 @@ void Forward::try_pmp(const std::string& iface, const std::string& gateway, std:
 			return;
 		}
 		
-		LOG_WARN_ASYNC(logger_, "Automatic port forwarding not permitted by NAT gateway"
-		                        " or gateway address is incorrectly configured");
+		log(Severity::warn,
+			"Automatic port forwarding not permitted by NAT gateway"
+		    " or gateway address is incorrectly configured"
+		);
 	});
 }
 
 void Forward::start_auto(const std::string& iface, const std::string& gateway, std::uint16_t port) {
-	LOG_INFO_ASYNC(logger_, "Attempting port forwarding with UPnP...");
+	log(Severity::info, "Attempting port forwarding with UPnP...");
 
 	start_upnp(iface, port);
 
@@ -189,7 +230,7 @@ void Forward::start_auto(const std::string& iface, const std::string& gateway, s
 			return;
 		}
 		
-		LOG_INFO_ASYNC(logger_, "Attempting port forwarding with NAT-PMP & PCP...");
+		log(Severity::info, "Attempting port forwarding with NAT-PMP & PCP...");
 		try_pmp(iface, gateway, port);
 	});
 }

--- a/src/libs/shared/shared/utility/STUN.h
+++ b/src/libs/shared/shared/utility/STUN.h
@@ -29,55 +29,31 @@ inline static stun::Client create_stun_client(const po::variables_map& args) {
 	);
 }
 
-inline static void stun_log_callback(stun::Verbosity verbosity, stun::Error reason, log::Logger& logger) {
-	constexpr std::string_view fmt = "[stun] {}";
-	const std::string_view reason_str = to_string(reason);
-
-	switch(verbosity) {
-		case stun::Verbosity::trivial:
-			LOG_TRACE_SYNC(logger, fmt, reason_str);
-			break;
-		case stun::Verbosity::debug:
-			LOG_DEBUG_SYNC(logger, fmt, reason_str);
-			break;
-		case stun::Verbosity::info:
-			LOG_INFO_SYNC(logger, fmt, reason_str);
-			break;
-		case stun::Verbosity::warn:
-			LOG_WARN_SYNC(logger, fmt, reason_str);
-			break;
-		case stun::Verbosity::error:
-			LOG_ERROR_SYNC(logger, fmt, reason_str);
-			break;
-		case stun::Verbosity::fatal:
-			LOG_FATAL_SYNC(logger, fmt, reason_str);
-			break;
-	}
-}
-
-inline void log_stun_result(stun::Client& client, const stun::MappedResult& result,
-                            const std::uint16_t port, log::Logger& logger) {
+inline void log_stun_result(stun::Client& client,
+                            const stun::MappedResult& result,
+                            const std::uint16_t port,
+                            log::Logger& logger) {
 	if(!result) {
-		LOG_ERROR_SYNC(logger, "STUN: Query failed ({})", stun::to_string(result.error().reason));
+		LOG_ERROR_SYNC(logger, "[stun] Query failed ({})", stun::to_string(result.error().reason));
 		return;
 	}
 
 	const auto& ip = stun::extract_ip_to_string(*result);
-	LOG_INFO_SYNC(logger, "STUN: Binding request succeeded ({})", ip);
+	LOG_INFO_SYNC(logger, "[stun] Binding request succeeded, external address is {}", ip);
 
 	const auto nat = client.nat_present().get();
 
 	if(!nat) {
-		LOG_WARN_SYNC(logger, "STUN: Unable to determine if gateway is behind NAT ({})",
+		LOG_WARN_SYNC(logger, "[stun] Unable to determine if gateway is behind NAT ({})",
 		                      stun::to_string(nat.error().reason));
 		return;
 	}
 
 	if(*nat) {
-		LOG_INFO_SYNC(logger, "STUN: Service appears to be behind NAT, "
+		LOG_INFO_SYNC(logger, "[stun] Service appears to be behind NAT, "
 		                      "forward port {} for external access", port);
 	} else {
-		LOG_INFO_SYNC(logger, "STUN: Service does not appear to be behind NAT - "
+		LOG_INFO_SYNC(logger, "[stun] Service does not appear to be behind NAT - "
 		                      "server is available online (firewall rules permitting)");
 	}
 }

--- a/src/libs/stun/CMakeLists.txt
+++ b/src/libs/stun/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(${LIBRARY_NAME} STATIC
     include/stun/Exception.h
     include/stun/detail/Shared.h
     include/stun/MessageBuilder.h
+    include/stun/LogSeverity.h
     src/Client.cpp
     src/DatagramTransport.cpp
     src/StreamTransport.cpp

--- a/src/libs/stun/include/stun/Client.h
+++ b/src/libs/stun/include/stun/Client.h
@@ -47,7 +47,7 @@ class Client final {
 	Protocol proto_;
 	std::unique_ptr<Transport> transport_;
 	RFCMode mode_;
-	LogCB logger_ = [](Verbosity, Error){};
+	LogCB logger_ = [](Severity, Error){};
 	std::unordered_map<std::string, std::chrono::steady_clock::time_point> dest_hist_;
 	std::string host_;
 	std::uint16_t port_;

--- a/src/libs/stun/include/stun/LogSeverity.h
+++ b/src/libs/stun/include/stun/LogSeverity.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Ember
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+namespace ember::stun {
+
+enum class Severity {
+	trace,
+	debug,
+	info,
+	warn,
+	error,
+	fatal
+};
+
+} // stun, ember

--- a/src/libs/stun/include/stun/Logging.h
+++ b/src/libs/stun/include/stun/Logging.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ember
+ * Copyright (c) 2024 - 2026 Ember
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -8,24 +8,12 @@
 
 #pragma once
 
+#include <stun/Attributes.h>
+#include <stun/LogSeverity.h>
 #include <shared/smartenum.hpp>
 #include <functional>
 
 namespace ember::stun {
-
-/*
- * STUN_LOG prefix is just to reduce the odds of annoying define collisions from
- * rage-inducing headers such as Windows.h when they end up being accidentally
- * transitively included through ten layers of crap.
- */
-enum class Verbosity {
-	trivial,
-	debug,
-	info,
-	warn,
-	error,
-	fatal
-};
 
 /*
  * Opting to provide the client (ourselves) with a reason enumeration rather than
@@ -75,6 +63,6 @@ struct ErrorRet {
 	attributes::ErrorCode ec;
 };
 
-using LogCB = std::function<void(Verbosity, Error)>;
+using LogCB = std::function<void(Severity, Error)>;
 
 } // stun, ember

--- a/src/libs/stun/include/stun/Parser.h
+++ b/src/libs/stun/include/stun/Parser.h
@@ -32,7 +32,7 @@ namespace be = boost::endian;
 
 class Parser final {
 	RFCMode mode_;
-	LogCB logger_ = [](Verbosity, Error) {};
+	LogCB logger_ = [](Severity, Error) {};
 	const std::span<const std::uint8_t> buffer_;
 
 	// individual attributes

--- a/src/libs/stun/include/stun/Parser.inl
+++ b/src/libs/stun/include/stun/Parser.inl
@@ -65,7 +65,7 @@ template<typename T>
 auto Parser::extract_utf8_text(spark::io::pmr::BinaryStreamReader& stream, const std::size_t size) {
 	// UTF8 encoded sequence of less than 128 characters (which can be as long as 763 bytes)
 	if(size > 763) {
-		logger_(Verbosity::debug, Error::resp_bad_software_attr);
+		logger_(Severity::debug, Error::resp_bad_software_attr);
 	}
 
 	T attr{};

--- a/src/libs/stun/src/Client.cpp
+++ b/src/libs/stun/src/Client.cpp
@@ -114,7 +114,7 @@ void Client::handle_message(std::span<const std::uint8_t> buffer) try {
 	std::lock_guard guard(mutex_);
 
 	if(buffer.size() < HEADER_LENGTH) {
-		logger_(Verbosity::debug, Error::resp_buffer_lt_header);
+		logger_(Severity::debug, Error::resp_buffer_lt_header);
 		return; // RFC says invalid messages should be discarded
 	}
 
@@ -127,7 +127,7 @@ void Client::handle_message(std::span<const std::uint8_t> buffer) try {
 	const auto hash = generate_key(header.tx_id, mode_);
 
 	if(tx_ && tx_->key != hash) {
-		logger_(Verbosity::debug, Error::resp_tx_not_found);
+		logger_(Severity::debug, Error::resp_tx_not_found);
 		return;
 	}
 
@@ -140,7 +140,7 @@ void Client::handle_message(std::span<const std::uint8_t> buffer) try {
 
 	process_message(buffer);
 } catch(const spark::exception& e) {
-	logger_(Verbosity::debug, Error::buffer_parse_error);
+	logger_(Severity::debug, Error::buffer_parse_error);
 }
 
 void Client::process_message(std::span<const std::uint8_t> buffer) try {

--- a/src/libs/stun/src/Parser.cpp
+++ b/src/libs/stun/src/Parser.cpp
@@ -142,7 +142,7 @@ Parser::error_code(spark::io::pmr::BinaryStreamReader& stream, std::size_t lengt
 	be::big_to_native_inplace(attr.code);
 
 	if(attr.code & 0xFFE00000) {
-		logger_(Verbosity::debug, Error::resp_error_code_out_of_range);
+		logger_(Severity::debug, Error::resp_error_code_out_of_range);
 	}
 
 	// (╯°□°）╯︵ ┻━┻
@@ -151,14 +151,14 @@ Parser::error_code(spark::io::pmr::BinaryStreamReader& stream, std::size_t lengt
 
 	if(code < 300 || code >= 700) {
 		if(mode_ != RFCMode::rfc3489) {
-			logger_(Verbosity::debug, Error::resp_error_code_out_of_range);
+			logger_(Severity::debug, Error::resp_error_code_out_of_range);
 		} else if(code < 100) { // original RFC has a wider range (1xx - 6xx)
-			logger_(Verbosity::debug, Error::resp_error_code_out_of_range);
+			logger_(Severity::debug, Error::resp_error_code_out_of_range);
 		}
 	}
 
 	if(num >= 100) {
-		logger_(Verbosity::debug, Error::resp_error_code_out_of_range);
+		logger_(Severity::debug, Error::resp_error_code_out_of_range);
 	}
 
 	attr.code = code + num;
@@ -194,7 +194,7 @@ Parser::unknown_attributes(spark::io::pmr::BinaryStreamReader& stream, std::size
 	}
 
 	if(attr.attributes.size() % 2) {
-		logger_(Verbosity::debug, Error::resp_unk_attr_bad_pad);
+		logger_(Severity::debug, Error::resp_unk_attr_bad_pad);
 	}
 
 	return attr;
@@ -341,12 +341,12 @@ bool Parser::check_attr_validity(const Attributes attr_type, const MessageType m
 			const auto res = std::ranges::find(rfc->second, mode_);
 
 			if(res == rfc->second.end()) { // definitely not our fault... probably
-				logger_(Verbosity::debug, Error::resp_bad_req_attr_server);
+				logger_(Severity::debug, Error::resp_bad_req_attr_server);
 				return false;
 			}
 		} else {
 			// might be our fault but probably not
-			logger_(Verbosity::debug, Error::resp_unknown_req_attribute);
+			logger_(Severity::debug, Error::resp_unknown_req_attribute);
 			return false;
 		}
 	}
@@ -359,12 +359,12 @@ bool Parser::check_attr_validity(const Attributes attr_type, const MessageType m
 	// Check whether this attribute is valid for the given response type
 	if(const auto entry = attr_valid_lut.find(attr_type); entry != attr_valid_lut.end()) {
 		if(entry->second != msg_type) { // not valid for this type
-			logger_(Verbosity::debug,
+			logger_(Severity::debug,
 				required? Error::resp_bad_req_attr_server : Error::resp_unknown_opt_attribute);
 			return false;
 		}
 	} else { // not valid for *any* response type
-		logger_(Verbosity::debug,
+		logger_(Severity::debug,
 			required? Error::resp_bad_req_attr_server : Error::resp_unknown_opt_attribute);
 		return false;
 	}

--- a/src/login/CMakeLists.txt
+++ b/src/login/CMakeLists.txt
@@ -62,6 +62,7 @@ set(LIBRARY_HDR
     LoginHandlerFwd.h
     SocketType.h
     Service.h
+    LoggingCallbacks.h
 )
 
 set(LIBRARY_SRC

--- a/src/login/LoggingCallbacks.h
+++ b/src/login/LoggingCallbacks.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Ember
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <logger/Logger.h>
+#include <stun/Logging.h>
+#include <conpool/LogSeverity.h>
+#include <ports/LogSeverity.h>
+#include <string_view>
+
+namespace ember {
+
+inline void forward_log_callback(ports::Severity severity, const std::string_view message, log::Logger& logger) {
+	constexpr std::string_view fmt = "[ports] {}";
+
+	switch(severity) {
+		case ports::Severity::debug:
+			LOG_DEBUG_ASYNC(logger, fmt, message);
+			break;
+		case ports::Severity::info:
+			LOG_INFO_ASYNC(logger, fmt, message);
+			break;
+		case ports::Severity::warn:
+			LOG_WARN_ASYNC(logger, fmt, message);
+			break;
+		case ports::Severity::error:
+			LOG_ERROR_ASYNC(logger, fmt, message);
+			break;
+		case ports::Severity::fatal:
+			LOG_FATAL_ASYNC(logger, fmt, message);
+			break;
+		default:
+			LOG_ERROR_ASYNC(logger, "Unhandled port forward log callback severity");
+			LOG_ERROR_ASYNC(logger, fmt, message);
+	}
+}
+
+inline static void stun_log_callback(stun::Severity severity, stun::Error reason, log::Logger& logger) {
+	constexpr std::string_view fmt = "[stun] {}";
+	const std::string_view reason_str = to_string(reason);
+
+	switch(severity) {
+		case stun::Severity::trace:
+			LOG_TRACE_SYNC(logger, fmt, reason_str);
+			break;
+		case stun::Severity::debug:
+			LOG_DEBUG_SYNC(logger, fmt, reason_str);
+			break;
+		case stun::Severity::info:
+			LOG_INFO_SYNC(logger, fmt, reason_str);
+			break;
+		case stun::Severity::warn:
+			LOG_WARN_SYNC(logger, fmt, reason_str);
+			break;
+		case stun::Severity::error:
+			LOG_ERROR_SYNC(logger, fmt, reason_str);
+			break;
+		case stun::Severity::fatal:
+			LOG_FATAL_SYNC(logger, fmt, reason_str);
+			break;
+		default:
+			LOG_ERROR_ASYNC(logger, "Unhandled STUN log callback severity");
+			LOG_ERROR_SYNC(logger, fmt, reason_str);
+	}
+}
+
+inline void pool_log_callback(connection_pool::Severity severity, std::string_view message, log::Logger& logger) {
+	constexpr std::string_view fmt = "[pool] {}";
+
+	switch(severity) {
+		case connection_pool::Severity::debug:
+			LOG_DEBUG_ASYNC(logger, fmt, message);
+			break;
+		case connection_pool::Severity::info:
+			LOG_INFO_ASYNC(logger, fmt, message);
+			break;
+		case connection_pool::Severity::warn:
+			LOG_WARN_ASYNC(logger, fmt, message);
+			break;
+		case connection_pool::Severity::error:
+			LOG_ERROR_ASYNC(logger, fmt, message);
+			break;
+		case connection_pool::Severity::fatal:
+			LOG_FATAL_ASYNC(logger, fmt, message);
+			break;
+		default:
+			LOG_ERROR_ASYNC(logger, "Unhandled connection pool log callback severity");
+			LOG_ERROR_ASYNC(logger, fmt, message);
+	}
+}
+
+} // ember

--- a/src/login/Service.cpp
+++ b/src/login/Service.cpp
@@ -10,6 +10,7 @@
 #include "AccountClient.h"
 #include "FilterTypes.h"
 #include "IntegrityData.h"
+#include "LoggingCallbacks.h"
 #include "LoginHandlerBuilder.h"
 #include "MonitorCallbacks.h"
 #include "NetworkListener.h"
@@ -76,7 +77,6 @@ constexpr std::size_t WORKER_NUM_HINT = 32;
 
 namespace ember::login {
 
-void pool_log_callback(ep::Severity, std::string_view message, log::Logger& logger);
 void print_lib_versions(log::Logger& logger);
 
 /*
@@ -151,8 +151,8 @@ void Service::launch(const po::variables_map& args, boost::asio::io_context& ser
 	std::future<stun::MappedResult> stun_res;
 
 	if(stun_enabled) {
-		stun.log_callback([&](const stun::Verbosity verbosity, const stun::Error reason) {
-			stun_log_callback(verbosity, reason, logger);
+		stun.log_callback([&](const stun::Severity severity, const stun::Error reason) {
+			stun_log_callback(severity, reason, logger);
 		});
 
 		LOG_INFO_SYNC(logger, "Starting STUN query...");
@@ -308,7 +308,9 @@ void Service::launch(const po::variables_map& args, boost::asio::io_context& ser
 				const auto& gateway = args["forward.gateway"].as<std::string>();
 
 				forward = std::make_unique<ports::Forward>(
-					logger, service, mode, interface, gateway, port
+					service, mode, interface, gateway, port, [&](auto severity, auto message) {
+						forward_log_callback(severity, message, logger);
+					}
 				);
 			}
 		} else if(!result && forward_enabled) {
@@ -357,29 +359,6 @@ std::unique_ptr<Metrics> Service::start_metrics(boost::asio::io_context& service
 	}
 
 	return metrics;
-}
-
-void pool_log_callback(ep::Severity severity, std::string_view message, log::Logger& logger) {
-	switch(severity) {
-		case ep::Severity::debug:
-			LOG_DEBUG(logger) << message << LOG_ASYNC;
-			break;
-		case ep::Severity::info:
-			LOG_INFO(logger) << message << LOG_ASYNC;
-			break;
-		case ep::Severity::warn:
-			LOG_WARN(logger) << message << LOG_ASYNC;
-			break;
-		case ep::Severity::error:
-			LOG_ERROR(logger) << message << LOG_ASYNC;
-			break;
-		case ep::Severity::fatal:
-			LOG_FATAL(logger) << message << LOG_ASYNC;
-			break;
-		default:
-			LOG_ERROR_ASYNC(logger, "Unhandled pool log callback severity");
-			LOG_ERROR(logger) << message << LOG_ASYNC;
-	}
 }
 
 po::options_description Service::options() {

--- a/src/tools/stun/main.cpp
+++ b/src/tools/stun/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 - 2025 Ember
+ * Copyright (c) 2023 - 2026 Ember
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -26,7 +26,7 @@ using namespace ember;
 
 void launch(const po::variables_map& args);
 po::variables_map parse_arguments(int argc, const char* argv[]);
-void log_cb(stun::Verbosity verbosity, stun::Error reason);
+void log_cb(stun::Severity severity, stun::Error reason);
 void print_error(const std::string_view test, const stun::ErrorRet& error);
 
 int main(int argc, const char* argv[]) try {
@@ -107,26 +107,26 @@ void print_error(const std::string_view test, const stun::ErrorRet& error) {
 	}
 }
 
-void log_cb(const stun::Verbosity verbosity, const stun::Error reason) {
+void log_cb(const stun::Severity severity, const stun::Error reason) {
 	std::string_view verbstr{};
 
-	switch(verbosity) {
-		case stun::Verbosity::trivial:
-			verbstr = "[trivial]";
+	switch(severity) {
+		case stun::Severity::trace:
+			verbstr = "[trace]";
 			break;
-		case stun::Verbosity::debug:
+		case stun::Severity::debug:
 			verbstr = "[debug]";
 			break;
-		case stun::Verbosity::info:
+		case stun::Severity::info:
 			verbstr = "[info]";
 			break;
-		case stun::Verbosity::warn:
+		case stun::Severity::warn:
 			verbstr = "[warn]";
 			break;
-		case stun::Verbosity::error:
+		case stun::Severity::error:
 			verbstr = "[error]";
 			break;
-		case stun::Verbosity::fatal:
+		case stun::Severity::fatal:
 			verbstr = "[fatal]";
 			break;
 		default:


### PR DESCRIPTION
Removed shared logging callbacks and instead each service gets its own. I think sharing this code, for dependency reasons and having differing callbacks, is the wrong move here.