### PR TITLE
Set INSTALL_GTEST to off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,7 @@ FetchContent_Declare(
   URL https://github.com/google/googletest/releases/download/v1.15.2/googletest-1.15.2.tar.gz
   URL_HASH SHA512=9046841044a2bf7edfd96854ad9c44ffae4fcb9fb59a075b367507c0762a98eb32cb6968d46663228272e26321e96f4dd287c95baa22c6af9bad902b8b6ede4e 
 )
+set(INSTALL_GTEST OFF)
 
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
Don't need all of their headers copied to the binary directory