### PR TITLE
Allow erasing by string_view

### DIFF
--- a/src/libs/core/commands/CMakeLists.txt
+++ b/src/libs/core/commands/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(${LIBRARY_NAME} STATIC
     include/commands/ScopedCommand.h
     include/commands/UserData.h
     include/commands/Flags.h
+    include/commands/detail/StringHash.h
 )
 
 target_include_directories(${LIBRARY_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/src/libs/core/commands/include/commands/Command.h
+++ b/src/libs/core/commands/include/commands/Command.h
@@ -15,6 +15,7 @@
 #include <commands/Flags.h>
 #include <commands/Result.h>
 #include <commands/ScopedCommand.h>
+#include <commands/detail/StringHash.h>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -31,7 +32,7 @@ namespace ember::commands {
 class Command;
 
 using CommandHandler = std::function<void(const args::Map&)>;
-using CommandMap = std::unordered_map<std::string, std::shared_ptr<Command>>;
+using CommandMap = std::unordered_map<std::string, std::shared_ptr<Command>, StringHash, std::equal_to<>>;
 
 class Command : public std::enable_shared_from_this<Command> {
 	mutable std::mutex mutex_;
@@ -75,7 +76,7 @@ public:
 	ScopedCommand scoped_insert(std::shared_ptr<Command> command);
 	bool erase_argument(const std::string& argument);
 	void clear_arguments();
-	std::optional<std::shared_ptr<Command>> erase(const std::string& name);
+	std::optional<std::shared_ptr<Command>> erase(const std::string_view name);
 	bool erase(const std::shared_ptr<const Command>& command);
 	void clear_commands();
 

--- a/src/libs/core/commands/include/commands/Registry.h
+++ b/src/libs/core/commands/include/commands/Registry.h
@@ -44,7 +44,7 @@ public:
 	std::shared_ptr<Command> insert(std::string name);
 	void insert(std::shared_ptr<Command> command);
 	ScopedCommand scoped_insert(std::shared_ptr<Command> command);
-	std::optional<std::shared_ptr<Command>> erase(const std::string& name);
+	std::optional<std::shared_ptr<Command>> erase(const std::string_view name);
 	bool erase(const std::shared_ptr<const Command> command);
 
 	Suggestions autocomplete(const std::string_view query) const;

--- a/src/libs/core/commands/include/commands/detail/StringHash.h
+++ b/src/libs/core/commands/include/commands/detail/StringHash.h
@@ -12,6 +12,8 @@
 #include <string_view>
 #include <cstddef>
 
+namespace ember::commands {
+
 struct StringHash {
 	using hash_type = std::hash<std::string_view>;
 	using is_transparent = void;
@@ -24,7 +26,9 @@ struct StringHash {
 		return hash_type{}(str);
 	}
 
-	std::size_t operator()(const std::string &str) const {
+	std::size_t operator()(const std::string& str) const {
 		return hash_type{}(str);
 	}
 };
+
+} // commands, ember

--- a/src/libs/core/commands/src/Command.cpp
+++ b/src/libs/core/commands/src/Command.cpp
@@ -223,13 +223,13 @@ void Command::clear_arguments() {
 auto Command::erase(const std::string_view name) -> std::optional<std::shared_ptr<Command>> {
 	std::lock_guard guard(mutex_);
 
-	auto result = commands_.extract(name);
-	
-	if(result.empty()) {
-		return std::nullopt;
+	// using an iterator to appease libstdc++ missing C++23 overloads
+	if(auto it = commands_.find(name); it != commands_.end()) {
+		auto result = commands_.extract(it);
+		return result.mapped();
 	}
 
-	return result.mapped();
+	return std::nullopt;
 }
 
 bool Command::erase(const std::shared_ptr<const Command>& command) {

--- a/src/libs/core/commands/src/Command.cpp
+++ b/src/libs/core/commands/src/Command.cpp
@@ -220,7 +220,7 @@ void Command::clear_arguments() {
 	args_.clear();
 }
 
-auto Command::erase(const std::string& name) -> std::optional<std::shared_ptr<Command>> {
+auto Command::erase(const std::string_view name) -> std::optional<std::shared_ptr<Command>> {
 	std::lock_guard guard(mutex_);
 
 	auto result = commands_.extract(name);

--- a/src/libs/core/commands/src/Registry.cpp
+++ b/src/libs/core/commands/src/Registry.cpp
@@ -158,7 +158,7 @@ Suggestions Registry::autocomplete(const std::string_view query) const {
 	return results;
 }
 
-std::optional<std::shared_ptr<Command>> Registry::erase(const std::string& name) {
+std::optional<std::shared_ptr<Command>> Registry::erase(const std::string_view name) {
 	return root_->erase(name);
 }
 


### PR DESCRIPTION
Copied StringHash rather than create a dependency on the shared lib for build speed reasons. Can remove once things are split up further or... modules. :)