### PR TITLE
Remove most usage of the old log API, rename macros to make async logging the default

### DIFF
--- a/src/account/AccountService.cpp
+++ b/src/account/AccountService.cpp
@@ -21,16 +21,16 @@ AccountService::AccountService(Server& spark, AccountHandler& handler, Sessions&
 	  logger_(logger) {}
 
 void AccountService::on_link_up(const Link& link) {
-	LOG_DEBUG_ASYNC(logger_, "Link up from {}", link.peer_banner);
+	LOG_DEBUG(logger_, "Link up from {}", link.peer_banner);
 }
 
 void AccountService::on_link_down(const Link& link) {
-	LOG_DEBUG_ASYNC(logger_, "Link down from {}", link.peer_banner);
+	LOG_DEBUG(logger_, "Link down from {}", link.peer_banner);
 }
 
 std::optional<SessionResponseT>
 AccountService::handle_session_fetch(const SessionLookup& msg, const Link& link, const Token& token) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	SessionResponseT response;
 
@@ -56,7 +56,7 @@ AccountService::handle_session_fetch(const SessionLookup& msg, const Link& link,
 
 std::optional<RegisterResponseT>
 AccountService::handle_register_session(const RegisterSession& msg,	const Link& link, const Token& token) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	RegisterResponseT response {
 		.status = Status::ok
@@ -77,7 +77,7 @@ AccountService::handle_register_session(const RegisterSession& msg,	const Link& 
 
 std::optional<AccountFetchResponseT>
 AccountService::handle_account_id_fetch(const LookupID& msg, const Link& link, const Token& token) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 	
 	if(!msg.account_name()) {
 		return AccountFetchResponseT {
@@ -110,13 +110,13 @@ AccountService::handle_account_id_fetch(const LookupID& msg, const Link& link, c
 
 std::optional<DisconnectSessionResponseT>
 AccountService::handle_disconnect_by_session(const DisconnectSession& msg, const Link& link, const Token& token) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 	return std::nullopt;
 }
 
 std::optional<DisconnectResponseT>
 AccountService::handle_disconnect_by_id(const DisconnectID& msg, const Link& link, const Token& token) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 	return std::nullopt; 
 }
 

--- a/src/account/LoggingCallbacks.h
+++ b/src/account/LoggingCallbacks.h
@@ -19,23 +19,23 @@ inline void pool_log_callback(connection_pool::Severity severity, std::string_vi
 
 	switch(severity) {
 		case connection_pool::Severity::debug:
-			LOG_DEBUG_ASYNC(logger, fmt, message);
+			LOG_DEBUG(logger, fmt, message);
 			break;
 		case connection_pool::Severity::info:
-			LOG_INFO_ASYNC(logger, fmt, message);
+			LOG_INFO(logger, fmt, message);
 			break;
 		case connection_pool::Severity::warn:
-			LOG_WARN_ASYNC(logger, fmt, message);
+			LOG_WARN(logger, fmt, message);
 			break;
 		case connection_pool::Severity::error:
-			LOG_ERROR_ASYNC(logger, fmt, message);
+			LOG_ERROR(logger, fmt, message);
 			break;
 		case connection_pool::Severity::fatal:
-			LOG_FATAL_ASYNC(logger, fmt, message);
+			LOG_FATAL(logger, fmt, message);
 			break;
 		default:
-			LOG_ERROR_ASYNC(logger, "Unhandled connection pool log callback severity");
-			LOG_ERROR_ASYNC(logger, fmt, message);
+			LOG_ERROR(logger, "Unhandled connection pool log callback severity");
+			LOG_ERROR(logger, fmt, message);
 	}
 }
 

--- a/src/account/Service.cpp
+++ b/src/account/Service.cpp
@@ -41,7 +41,7 @@ int Service::run(const opts::variables_map& args) try {
 	ioc.run();
 	return EXIT_SUCCESS;
 } catch(const std::exception& e) {
-	LOG_FATAL_SYNC(logger, e.what());
+	SLOG_FATAL(logger, e.what());
 	return EXIT_FAILURE;
 }
 
@@ -49,30 +49,30 @@ void Service::initialise(const opts::variables_map& args) {
 	const auto time = std::chrono::steady_clock::now();
 	auto ctx = context.get();
 	
-	LOG_INFO_SYNC(logger, "Initialising database connection pool...");
+	SLOG_INFO(logger, "Initialising database connection pool...");
 	ctx->conn_pool = std::make_unique<connection_pool::Pool<drivers::AutoSelect>>(
 		init_database(args, logger)
 	);
 
-	LOG_INFO_SYNC(logger,"Initialising DAOs...");
+	SLOG_INFO(logger,"Initialising DAOs...");
 	auto user_dao = dal::user_dao(ctx->conn_pool->get());
 	ctx->user_dao = std::make_unique<decltype(user_dao)>(std::move(user_dao));
 
 	const auto concurrency = thread::hardware_concurrency([&](auto msg) {
-		LOG_ERROR_SYNC(logger, msg);
+		SLOG_ERROR(logger, msg);
 	});
 
-	LOG_INFO_SYNC(logger, "Starting thread pool with {} threads...", concurrency);
+	SLOG_INFO(logger, "Starting thread pool with {} threads...", concurrency);
 	ctx->thread_pool = std::make_unique<thread::ThreadPool>(
 		concurrency
 	);
 
-	LOG_INFO_SYNC(logger, "Initialising account handler..."); 
+	SLOG_INFO(logger, "Initialising account handler..."); 
 	ctx->account_handler = std::make_unique<AccountHandler>(
 		*ctx->user_dao, *ctx->thread_pool
 	);
 
-	LOG_INFO_SYNC(logger, "Starting RPC services...");
+	SLOG_INFO(logger, "Starting RPC services...");
 	ctx->sessions = std::make_unique<Sessions>(true);
 
 	const auto& s_address = args["spark.address"].as<std::string>();
@@ -88,7 +88,7 @@ void Service::initialise(const opts::variables_map& args) {
 
 	// All done setting up
 	boost::asio::dispatch(ioc, [&, time]() {
-		LOG_INFO_SYNC(logger, "{} started successfully in {}", app_name,
+		SLOG_INFO(logger, "{} started successfully in {}", app_name,
 			utility::time_elapsed_format(time));
 
 		start_time = std::chrono::steady_clock::now();
@@ -102,7 +102,7 @@ void Service::stop() {
 		return;
 	}
 
-	LOG_TRACE_SYNC(logger, "Service termination requested");
+	SLOG_TRACE(logger, "Service termination requested");
 	auto ctx = context.get();
 
 	boost::asio::post(ioc, [&] {

--- a/src/account/main.cpp
+++ b/src/account/main.cpp
@@ -47,16 +47,16 @@ int main(int argc, const char* argv[]) try {
 	log::Logger logger;
 	utility::configure_logger(logger, args);
 	log::global_logger(logger);
-	LOG_INFO_SYNC(logger, "Logger configured successfully");
+	SLOG_INFO(logger, "Logger configured successfully");
 
-	LOG_DEBUG_SYNC(logger, "Registering command handlers...");
+	SLOG_DEBUG(logger, "Registering command handlers...");
 	const auto suggestions = args["console_log.suggestions"].as<bool>();
 	commands::Registry registry;
 	utility::register_command_handlers(registry, logger, suggestions);
 	utility::register_shared_commands(registry, logger);
 
 	const auto ret = run(args, logger, registry);
-	LOG_INFO_SYNC(logger, "{} terminated (returned '{}')", account::app_name, ret);
+	SLOG_INFO(logger, "{} terminated (returned '{}')", account::app_name, ret);
 	return ret;
 } catch(const std::exception& e) {
 	std::cerr << e.what();
@@ -74,7 +74,7 @@ int run(const opts::variables_map& args, log::Logger& logger, commands::Registry
 			return;
 		}
 
-		LOG_DEBUG_SYNC(logger, "Received signal {}({})", utility::sig_str(signal), signal);
+		SLOG_DEBUG(logger, "Received signal {}({})", utility::sig_str(signal), signal);
 		service.stop();
 	});
 

--- a/src/character/CharacterHandler.cpp
+++ b/src/character/CharacterHandler.cpp
@@ -18,7 +18,7 @@ namespace ember {
 void CharacterHandler::create(std::uint32_t account_id, std::uint32_t realm_id,
                               const rpc::Character::CharacterTemplate& options,
                               ResultCB callback) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	Character character{};
 	character.race = options.race();
@@ -44,7 +44,7 @@ void CharacterHandler::create(std::uint32_t account_id, std::uint32_t realm_id,
 }
 
 void CharacterHandler::restore(std::uint64_t id, ResultCB callback) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	pool_.run([=, this] {
 		do_restore(id, callback);
@@ -53,7 +53,7 @@ void CharacterHandler::restore(std::uint64_t id, ResultCB callback) const {
 
 void CharacterHandler::erase(std::uint32_t account_id, std::uint32_t realm_id,
                              std::uint64_t character_id, ResultCB callback) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	pool_.run([=, this] {
 		do_erase(account_id, realm_id, character_id, callback);
@@ -62,7 +62,7 @@ void CharacterHandler::erase(std::uint32_t account_id, std::uint32_t realm_id,
 
 void CharacterHandler::enumerate(std::uint32_t account_id, std::uint32_t realm_id,
                                  EnumResultCB callback) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	pool_.run([=, this] {
 		do_enumerate(account_id, realm_id, callback);
@@ -71,7 +71,7 @@ void CharacterHandler::enumerate(std::uint32_t account_id, std::uint32_t realm_i
 
 void CharacterHandler::rename(std::uint32_t account_id, std::uint64_t character_id,
                               const utf8_string& name, RenameCB callback) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	pool_.run([=, this] {
 		do_rename(account_id, character_id, name, callback);
@@ -80,7 +80,7 @@ void CharacterHandler::rename(std::uint32_t account_id, std::uint64_t character_
 
 void CharacterHandler::do_create(std::uint32_t account_id, std::uint32_t realm_id,
                                  Character character, const ResultCB& callback) const try {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	// class, race and visual customisation validation
 	const bool success = validate_options(character, account_id);
@@ -138,7 +138,7 @@ void CharacterHandler::do_create(std::uint32_t account_id, std::uint32_t realm_i
 		auto current = pvp_faction(*dbc_.chr_races[characters.front().race]->faction);
 		auto opposing = pvp_faction(*dbc_.chr_races[character.race]->faction);
 
-		LOG_DEBUG_ASYNC(logger_, "Cannot create {} characters with existing {} characters on a PvP realm",
+		LOG_DEBUG(logger_, "Cannot create {} characters with existing {} characters on a PvP realm",
 		                opposing->internal_name, current->internal_name);
 
 		callback(protocol::Result::char_create_pvp_teams_violation);
@@ -155,7 +155,7 @@ void CharacterHandler::do_create(std::uint32_t account_id, std::uint32_t realm_i
 	});
 
 	if(base_info == dbc_.char_start_base.end()) {
-		LOG_ERROR_ASYNC(logger_, "Unable to find base data for {} {}",
+		LOG_ERROR(logger_, "Unable to find base data for {} {}",
 		                race->name.en_gb, class_->name.en_gb);
 		callback(protocol::Result::char_create_error);
 		return;
@@ -165,7 +165,7 @@ void CharacterHandler::do_create(std::uint32_t account_id, std::uint32_t realm_i
 	const auto zone = base_info->second.zone;
 
 	if(!zone) {
-		LOG_ERROR_ASYNC(logger_, "Unable to find zone data for {} {}",
+		LOG_ERROR(logger_, "Unable to find zone data for {} {}",
 		                race->name.en_gb, class_->name.en_gb);
 		callback(protocol::Result::char_create_error);
 		return;
@@ -184,7 +184,7 @@ void CharacterHandler::do_create(std::uint32_t account_id, std::uint32_t realm_i
 	if(items != dbc_.char_start_outfit.end()) {
 		populate_items(character, items->second);
 	} else { // could be intentional, so we'll keep going
-		LOG_DEBUG_ASYNC(logger_, "No starting item data found for {}, {}",
+		LOG_DEBUG(logger_, "No starting item data found for {}, {}",
 		                race->name.en_gb, class_->name.en_gb);
 	}
 
@@ -196,7 +196,7 @@ void CharacterHandler::do_create(std::uint32_t account_id, std::uint32_t realm_i
 	if(spells != dbc_.char_start_spells.end()) {
 		populate_spells(character, spells->second);
 	} else { // could be intentional, so we'll keep going
-		LOG_DEBUG_ASYNC(logger_, "No starting spell data found for {} {}",
+		LOG_DEBUG(logger_, "No starting spell data found for {} {}",
 		                race->name.en_gb, class_->name.en_gb);
 	}
 
@@ -209,7 +209,7 @@ void CharacterHandler::do_create(std::uint32_t account_id, std::uint32_t realm_i
 	if(skills != dbc_.char_start_skills.end()) {
 		populate_skills(character, skills->second);
 	} else { // could be intentional, so we'll keep going
-		LOG_DEBUG_ASYNC(logger_, "No starting skill data found for {} {}",
+		LOG_DEBUG(logger_, "No starting skill data found for {} {}",
 		                race->name.en_gb, class_->name.en_gb);
 	}
 
@@ -219,7 +219,7 @@ void CharacterHandler::do_create(std::uint32_t account_id, std::uint32_t realm_i
 		subzone = zone->area->parent_area_table->area_name.en_gb.c_str();
 	}
 
-	LOG_DEBUG_ASYNC(logger_, "Creating {} {} at {}{} {}", 
+	LOG_DEBUG(logger_, "Creating {} {} at {}{} {}", 
 	                race->name.en_gb,
 	                class_->name.en_gb,
 	                zone->area->area_name.en_gb,
@@ -229,19 +229,19 @@ void CharacterHandler::do_create(std::uint32_t account_id, std::uint32_t realm_i
 	dao_.create(character);
 	callback(protocol::Result::char_create_success);
 } catch(const dal::exception& e) {
-	LOG_ERROR(logger_) << e.what() << LOG_ASYNC;
+	LOG_ERROR(logger_, e.what());
 	callback(protocol::Result::char_create_error);
 }
 
 void CharacterHandler::do_erase(std::uint32_t account_id, std::uint32_t realm_id,
                                 std::uint64_t character_id, const ResultCB& callback) const try {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	auto character = dao_.character(character_id);
 	
 	// character must exist, belong to the same account and be on the same realm
 	if(!character || character->account_id != account_id || character->realm_id != realm_id) {
-		LOG_DEBUG_ASYNC(logger_, "Account {} attempted an invalid delete on character ", account_id, character_id);
+		LOG_DEBUG(logger_, "Account {} attempted an invalid delete on character ", account_id, character_id);
 		callback(protocol::Result::char_delete_failed);
 		return;
 	}
@@ -257,29 +257,29 @@ void CharacterHandler::do_erase(std::uint32_t account_id, std::uint32_t realm_id
 		return;
 	}
 
-	LOG_DEBUG_ASYNC(logger_, "Deleting {}, #{}", character->name, character->id);
+	LOG_DEBUG(logger_, "Deleting {}, #{}", character->name, character->id);
 
 	dao_.delete_character(character_id, true);
 	callback(protocol::Result::char_delete_success);
 } catch(const dal::exception& e) {
-	LOG_ERROR(logger_) << e.what() << LOG_ASYNC;
+	LOG_ERROR(logger_, e.what());
 	callback(protocol::Result::char_delete_failed);
 }
 
 void CharacterHandler::do_enumerate(std::uint32_t account_id, std::uint32_t realm_id,
                                     const EnumResultCB& callback) const try {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	auto characters = dao_.characters(account_id, realm_id);
 	callback(true, std::move(characters));
 } catch(const dal::exception& e) {
-	LOG_ERROR(logger_) << e.what() << LOG_ASYNC;
+	LOG_ERROR(logger_, e.what());
 	callback(false, {});
 }
 
 void CharacterHandler::do_rename(std::uint32_t account_id, std::uint64_t character_id,
                                  const utf8_string& name, const RenameCB& callback) const try {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	auto character = dao_.character(character_id);
 	
@@ -314,7 +314,7 @@ void CharacterHandler::do_rename(std::uint32_t account_id, std::uint64_t charact
 		return;
 	}
 	
-	LOG_DEBUG_ASYNC(logger_, "Renaming {} => {}, #{}", character->name, name, character->id);
+	LOG_DEBUG(logger_, "Renaming {} => {}, #{}", character->name, name, character->id);
 
 	character->internal_name = character->name;
 	character->flags ^= Character::Flags::rename;
@@ -322,18 +322,18 @@ void CharacterHandler::do_rename(std::uint32_t account_id, std::uint64_t charact
 	dao_.update(*character);
 	callback(protocol::Result::response_success, *character);
 } catch(const dal::exception& e) {
-	LOG_ERROR(logger_) << e.what() << LOG_ASYNC;
+	LOG_ERROR(logger_, e.what());
 	callback(protocol::Result::char_name_failure, std::nullopt);
 }
 
 void CharacterHandler::do_restore(std::uint64_t id, const ResultCB& callback) const try {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	auto character = dao_.character(id);
 	auto characters = dao_.characters(character->account_id);
 
 	if(characters.size() >= config_.max_chars_slots_account) {
-		LOG_WARN_ASYNC(logger_, "Cannot restore character - would exceed max account slots");
+		LOG_WARN(logger_, "Cannot restore character - would exceed max account slots");
 		callback(protocol::Result::char_create_account_limit);
 		return;
 	}
@@ -343,7 +343,7 @@ void CharacterHandler::do_restore(std::uint64_t id, const ResultCB& callback) co
 	});
 
 	if(realm_chars >= config_.max_chars_slots_server) {
-		LOG_WARN_ASYNC(logger_, "Cannot restore character - would exceed max server slots");
+		LOG_WARN(logger_, "Cannot restore character - would exceed max server slots");
 		callback(protocol::Result::char_create_server_limit);
 		return;
 	}
@@ -357,18 +357,18 @@ void CharacterHandler::do_restore(std::uint64_t id, const ResultCB& callback) co
 		character->internal_name = character->name;
 	}
 
-	LOG_DEBUG_ASYNC(logger_, "Restoring {}, #{}", character->name, character->id);
+	LOG_DEBUG(logger_, "Restoring {}, #{}", character->name, character->id);
 
 	dao_.update(*character);
 	dao_.restore(id);
 	callback(protocol::Result::response_success);
 } catch(const dal::exception& e) {
-	LOG_ERROR(logger_) << e.what() << LOG_ASYNC;
+	LOG_ERROR(logger_, e.what());
 	callback(protocol::Result::response_failure);
 }
 
 bool CharacterHandler::validate_options(const Character& character, std::uint32_t account_id) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	// validate the race/class combination
 	auto found = std::ranges::find_if(dbc_.char_base_info, [&](auto val) {
@@ -376,7 +376,7 @@ bool CharacterHandler::validate_options(const Character& character, std::uint32_
 	});
 
 	if(found == dbc_.char_base_info.end()) {
-		LOG_DEBUG_ASYNC(logger_, "Invalid race/class combination of {} {} from account ID {}",
+		LOG_DEBUG(logger_, "Invalid race/class combination of {} {} from account ID {}",
 		                character.race, character.class_, account_id);
 		return false;
 	}
@@ -434,7 +434,7 @@ bool CharacterHandler::validate_options(const Character& character, std::uint32_
 	}
 
 	if(!facial_feature_match || !skin_match || !face_match || !hair_match) {
-		LOG_DEBUG_ASYNC(logger_, "Invalid visual customisation options, account {} - "
+		LOG_DEBUG(logger_, "Invalid visual customisation options, account {} - "
 		               "Face ID: {}, facial feature ID: {}, hair style ID: {}, hair colour ID: {}",
 			            account_id, character.face, character.facialhair, character.hairstyle, character.haircolour);
 		return false;
@@ -444,7 +444,7 @@ bool CharacterHandler::validate_options(const Character& character, std::uint32_
 }
 
 protocol::Result CharacterHandler::validate_name(const utf8_string& name) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	if(name.empty()) {
 		return protocol::Result::char_name_no_name;
@@ -482,7 +482,7 @@ protocol::Result CharacterHandler::validate_name(const utf8_string& name) const 
 		if(ret >= 0) {
 			return protocol::Result::char_name_reserved;
 		} else if(ret != PCRE_ERROR_NOMATCH) {
-			LOG_ERROR_ASYNC(logger_, "PCRE error encountered: {}", ret);
+			LOG_ERROR(logger_, "PCRE error encountered: {}", ret);
 			return protocol::Result::char_name_failure;
 		}
 	}
@@ -493,7 +493,7 @@ protocol::Result CharacterHandler::validate_name(const utf8_string& name) const 
 		if(ret >= 0) {
 			return protocol::Result::char_name_profane;
 		} else if(ret != PCRE_ERROR_NOMATCH) {
-			LOG_ERROR_ASYNC(logger_, "PCRE error encountered: {}", ret);
+			LOG_ERROR(logger_, "PCRE error encountered: {}", ret);
 			return protocol::Result::char_name_failure;
 		}
 	}
@@ -504,7 +504,7 @@ protocol::Result CharacterHandler::validate_name(const utf8_string& name) const 
 		if(ret >= 0) {
 			return protocol::Result::char_name_reserved;
 		} else if(ret != PCRE_ERROR_NOMATCH) {
-			LOG_ERROR_ASYNC(logger_, "PCRE error encountered: {}", ret);
+			LOG_ERROR(logger_, "PCRE error encountered: {}", ret);
 			return protocol::Result::char_name_failure;
 		}
 	}

--- a/src/character/CharacterService.cpp
+++ b/src/character/CharacterService.cpp
@@ -20,16 +20,16 @@ CharacterService::CharacterService(Server& server, const CharacterHandler& handl
 	  logger_(logger) {}
 
 void CharacterService::on_link_up(const Link& link) {
-	LOG_DEBUG_ASYNC(logger_, "Link up: {}", link.peer_banner);
+	LOG_DEBUG(logger_, "Link up: {}", link.peer_banner);
 }
 
 void CharacterService::on_link_down(const Link& link) {
-	LOG_DEBUG_ASYNC(logger_, "Link down: {}", link.peer_banner);
+	LOG_DEBUG(logger_, "Link down: {}", link.peer_banner);
 }
 
 std::optional<CreateResponseT>
 CharacterService::handle_create(const Create& msg, const Link& link, const Token& token) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	if(!msg.character()) {
 		return CreateResponseT {
@@ -51,10 +51,10 @@ CharacterService::handle_create(const Create& msg, const Link& link, const Token
 
 std::optional<DeleteResponseT>
 CharacterService::handle_delete(const Delete& msg, const Link& link, const Token& token) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	handler_.erase(msg.account_id(), msg.realm_id(), msg.character_id(), [=, this](auto res) {
-		LOG_DEBUG_ASYNC(logger_, "Deletion response: {}", protocol::to_string(res));
+		LOG_DEBUG(logger_, "Deletion response: {}", protocol::to_string(res));
 
 		DeleteResponseT msg {
 			.status = Status::ok,
@@ -69,7 +69,7 @@ CharacterService::handle_delete(const Delete& msg, const Link& link, const Token
 
 std::optional<RenameResponseT> 
 CharacterService::handle_rename(const Rename& msg, const Link& link, const Token& token) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	if(!msg.name()) {
 		return RenameResponseT{
@@ -88,7 +88,7 @@ CharacterService::handle_rename(const Rename& msg, const Link& link, const Token
 
 std::optional<RetrieveResponseT>
 CharacterService::handle_enumerate(const Retrieve& msg, const Link& link, const Token& token) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	handler_.enumerate(msg.account_id(), msg.realm_id(), [=, this](auto res, auto characters) {
 		send_characters(res, characters, link, token);
@@ -101,7 +101,7 @@ void CharacterService::send_rename(const protocol::Result& res,
                                    const std::optional<const ember::Character>& character,
                                    const Link& link,
                                    const Token& token) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	RenameResponseT response {
 		.status = Status::ok,
@@ -120,7 +120,7 @@ void CharacterService::send_characters(const bool result,
                                        std::span<const ember::Character> characters,
                                        const Link& link,
                                        const Token& token) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	// painful
 	std::vector<std::unique_ptr<CharacterT>> chars;

--- a/src/character/LoggingCallbacks.h
+++ b/src/character/LoggingCallbacks.h
@@ -19,23 +19,23 @@ inline void pool_log_callback(connection_pool::Severity severity, std::string_vi
 
 	switch(severity) {
 		case connection_pool::Severity::debug:
-			LOG_DEBUG_ASYNC(logger, fmt, message);
+			LOG_DEBUG(logger, fmt, message);
 			break;
 		case connection_pool::Severity::info:
-			LOG_INFO_ASYNC(logger, fmt, message);
+			LOG_INFO(logger, fmt, message);
 			break;
 		case connection_pool::Severity::warn:
-			LOG_WARN_ASYNC(logger, fmt, message);
+			LOG_WARN(logger, fmt, message);
 			break;
 		case connection_pool::Severity::error:
-			LOG_ERROR_ASYNC(logger, fmt, message);
+			LOG_ERROR(logger, fmt, message);
 			break;
 		case connection_pool::Severity::fatal:
-			LOG_FATAL_ASYNC(logger, fmt, message);
+			LOG_FATAL(logger, fmt, message);
 			break;
 		default:
-			LOG_ERROR_ASYNC(logger, "Unhandled connection pool log callback severity");
-			LOG_ERROR_ASYNC(logger, fmt, message);
+			LOG_ERROR(logger, "Unhandled connection pool log callback severity");
+			LOG_ERROR(logger, fmt, message);
 	}
 }
 

--- a/src/character/Service.cpp
+++ b/src/character/Service.cpp
@@ -46,7 +46,7 @@ int Service::run(const opts::variables_map& args) try {
 	ioc.run();
 	return EXIT_SUCCESS;
 } catch(const std::exception& e) {
-	LOG_FATAL_SYNC(logger, e.what());
+	SLOG_FATAL(logger, e.what());
 	return EXIT_FAILURE;
 }
 
@@ -54,21 +54,21 @@ void Service::initialise(const opts::variables_map& args) {
 	const auto time = std::chrono::steady_clock::now();
 	auto ctx = context.get();
 
-	LOG_INFO_SYNC(logger, "Loading DBC data...");
+	SLOG_INFO(logger, "Loading DBC data...");
 	dbc::DiskLoader loader(
 		args["dbc.path"].as<std::string>(), [&](auto message) {
-			LOG_DEBUG(logger) << message << LOG_SYNC;
+			SLOG_DEBUG(logger, message);
 		}
 	);
 
 	auto dbcs = loader.load(dbcs_required);
 	ctx->dbcs = std::make_unique<dbc::Storage>(std::move(dbcs));
 
-	LOG_INFO_SYNC(logger, "Resolving DBC references...");
+	SLOG_INFO(logger, "Resolving DBC references...");
 	dbc::link(*ctx->dbcs);
 
 	// todo, should probably do this somewhere else
-	LOG_INFO_SYNC(logger, "Compiling DBC regular expressions...");
+	SLOG_INFO(logger, "Compiling DBC regular expressions...");
 	std::vector<utility::pcre::Result> profanity, reserved, spam;
 
 	for(auto& record : ctx->dbcs->names_profanity | std::views::values) {
@@ -84,7 +84,7 @@ void Service::initialise(const opts::variables_map& args) {
 	}
 
 	const auto concurrency = thread::hardware_concurrency([&](auto msg) {
-		LOG_ERROR_SYNC(logger, msg);
+		SLOG_ERROR(logger, msg);
 	});
 
 	const auto min_conns = args["database.min_connections"].as<unsigned short>();
@@ -94,14 +94,14 @@ void Service::initialise(const opts::variables_map& args) {
 		max_conns = concurrency;
 	}
 
-	LOG_INFO_SYNC(logger, "Max. database connections set to {} ({} cores)", max_conns, concurrency);
+	SLOG_INFO(logger, "Max. database connections set to {} ({} cores)", max_conns, concurrency);
 
-	LOG_INFO_SYNC(logger, "Initialising database connection pool...");
+	SLOG_INFO(logger, "Initialising database connection pool...");
 	ctx->conn_pool = std::make_unique<connection_pool::Pool<drivers::AutoSelect>>(
 		init_database(args, logger)
 	);
 
-	LOG_INFO_SYNC(logger, "Initialising DAOs...");
+	SLOG_INFO(logger, "Initialising DAOs...");
 	auto character_dao = dal::character_dao(ctx->conn_pool->get());
 	ctx->character_dao = std::make_unique<decltype(character_dao)>(std::move(character_dao));
 
@@ -111,10 +111,10 @@ void Service::initialise(const opts::variables_map& args) {
 		.max_chars_slots_server = args["max_chars_slots_server"].as<unsigned int>()
 	};
 
-	LOG_INFO_SYNC(logger, "Starting thread pool with {} threads...", concurrency);
+	SLOG_INFO(logger, "Starting thread pool with {} threads...", concurrency);
 	ctx->thread_pool = std::make_unique<thread::ThreadPool>(concurrency);
 
-	LOG_INFO_SYNC(logger, "Starting character handler...");
+	SLOG_INFO(logger, "Starting character handler...");
 	ctx->character_handler = std::make_unique<CharacterHandler>(
 		std::move(profanity), std::move(reserved), std::move(spam),
 	    *ctx->dbcs, *ctx->character_dao, config, *ctx->thread_pool, logger
@@ -123,7 +123,7 @@ void Service::initialise(const opts::variables_map& args) {
 	const auto&  s_address = args["spark.address"].as<std::string>();
 	const auto s_port = args["spark.port"].as<std::uint16_t>();
 
-	LOG_INFO_SYNC(logger, "Starting RPC services...");
+	SLOG_INFO(logger, "Starting RPC services...");
 	ctx->spark = std::make_unique<spark::Server>(
 		ioc, app_name, s_address, s_port, logger
 	);
@@ -134,7 +134,7 @@ void Service::initialise(const opts::variables_map& args) {
 	
 	// All done setting up
 	boost::asio::dispatch(ioc, [&, time]() {
-		LOG_INFO_SYNC(logger, "{} started successfully in {}", app_name,
+		SLOG_INFO(logger, "{} started successfully in {}", app_name,
 			utility::time_elapsed_format(time));
 
 		start_time = std::chrono::steady_clock::now();
@@ -148,7 +148,7 @@ void Service::stop() {
 		return;
 	}
 
-	LOG_TRACE_SYNC(logger, "Service termination requested");
+	SLOG_TRACE(logger, "Service termination requested");
 	auto ctx = context.get();
 
 	boost::asio::post(ioc, [&] {
@@ -159,7 +159,7 @@ void Service::stop() {
 }
 
 Service::~Service() {
-	LOG_TRACE_SYNC(logger, "Service termination requested");
+	SLOG_TRACE(logger, "Service termination requested");
 	stop();
 }
 

--- a/src/character/main.cpp
+++ b/src/character/main.cpp
@@ -47,16 +47,16 @@ int main(int argc, const char* argv[]) try {
 	log::Logger logger;
 	utility::configure_logger(logger, args);
 	log::global_logger(logger);
-	LOG_INFO_SYNC(logger, "Logger configured successfully");
+	SLOG_INFO(logger, "Logger configured successfully");
 
-	LOG_DEBUG_SYNC(logger, "Registering command handlers...");
+	SLOG_DEBUG(logger, "Registering command handlers...");
 	const auto suggestions = args["console_log.suggestions"].as<bool>();
 	commands::Registry registry;
 	utility::register_command_handlers(registry, logger, suggestions);
 	utility::register_shared_commands(registry, logger);
 
 	const auto ret = run(args, logger, registry);
-	LOG_INFO_SYNC(logger, "{} terminated (returned '{}')", character::app_name, ret);
+	SLOG_INFO(logger, "{} terminated (returned '{}')", character::app_name, ret);
 	return ret;
 } catch(const std::exception& e) {
 	std::cerr << e.what();
@@ -74,7 +74,7 @@ int run(const opts::variables_map& args, log::Logger& logger, commands::Registry
 			return;
 		}
 
-		LOG_DEBUG_SYNC(logger, "Received signal {}({})", utility::sig_str(signal), signal);
+		SLOG_DEBUG(logger, "Received signal {}({})", utility::sig_str(signal), signal);
 		signals.clear();
 		service.stop();
 	});
@@ -88,7 +88,7 @@ int run(const opts::variables_map& args, log::Logger& logger, commands::Registry
 	signals.cancel();
 	return ret;
 } catch(const std::exception& e) {
-	LOG_FATAL_SYNC(logger, e.what());
+	SLOG_FATAL(logger, e.what());
 	return EXIT_FAILURE;
 }
 

--- a/src/fusion/CommandHelpers.cpp
+++ b/src/fusion/CommandHelpers.cpp
@@ -24,10 +24,10 @@
 namespace ember::fusion {
 
 void log_subcommands(log::Logger& logger, const std::string& path, const commands::CommandMap& subcommands) {
-	LOG_CONSOLE_ASYNC(logger, R"(Available subcomands for "{}": )", path);
+	LOG_CONSOLE(logger, R"(Available subcomands for "{}": )", path);
 
 	for(auto& subcommand : subcommands | std::views::values) {
-		LOG_CONSOLE_ASYNC(logger, "{} : {}", subcommand->name(), subcommand->description());
+		LOG_CONSOLE(logger, "{} : {}", subcommand->name(), subcommand->description());
 	}
 }
 
@@ -37,19 +37,19 @@ void handle_command_result(commands::Result result, const std::string& path,
         case commands::Result::missing_args:
 			[[fallthrough]];
         case commands::Result::too_many_args:
-			LOG_CONSOLE_ERROR_ASYNC(logger, "Usage: {} {}", path, command.usage_string());
+			LOG_CONERR(logger, "Usage: {} {}", path, command.usage_string());
             break;
         case commands::Result::subcommands:
 			log_subcommands(logger, path, command.commands());
             break;
         case commands::Result::unavailable:
-			LOG_CONSOLE_ERROR_ASYNC(logger, R"(Command "{}" is currently unavailable.)", path);
+			LOG_CONERR(logger, R"(Command "{}" is currently unavailable.)", path);
             break;
 		case commands::Result::invalid_types:
-			LOG_CONSOLE_ERROR_ASYNC(logger, R"(Bad argument types when attempting to execute "{}")", path);
+			LOG_CONERR(logger, R"(Bad argument types when attempting to execute "{}")", path);
 			break;
         default:
-			LOG_CONSOLE_ERROR_ASYNC(logger, R"(An unhandled error occurred while executing "{}")", path);
+			LOG_CONERR(logger, R"(An unhandled error occurred while executing "{}")", path);
             break;
     }
 }
@@ -73,7 +73,7 @@ void execute_command(const std::string_view input, const Registries& registries,
 	const auto search = registry.find(token_view);
 
 	if(!search.command) {
-		LOG_CONSOLE_ERROR_ASYNC(
+		LOG_CONERR(
 			logger,
 			R"(Command "{}" not found)",
 			token_view.front()
@@ -90,7 +90,7 @@ void execute_command(const std::string_view input, const Registries& registries,
 	 * trigger from here. This check is only for user feedback, it is not required for correct behaviour.
 	 */
 	if(arguments.size() > search.command->argument_count()) {
-		LOG_CONSOLE_ERROR_ASYNC(
+		LOG_CONERR(
 			logger,
 			R"(Too many arguments passed to "{}" (takes {}, got {}))",
 			token_view.front(),
@@ -115,18 +115,18 @@ void execute_command(const std::string_view input, const Registries& registries,
 		handle_command_result(result, path, *search.command, logger);
 	}
 } catch(const commands::parse_error& e) {
-	LOG_CONSOLE_ERROR_ASYNC(logger, R"(Error parsing command arguments, "{}")", e.what());
+	LOG_CONERR(logger, R"(Error parsing command arguments, "{}")", e.what());
 } catch(const boost::bad_lexical_cast&) {
-	LOG_CONSOLE_ERROR_ASYNC(logger, R"(Unable to execute command, invalid argument types provided)");
+	LOG_CONERR(logger, R"(Unable to execute command, invalid argument types provided)");
 } catch(const std::exception& e) {
-	LOG_CONSOLE_ERROR_ASYNC(logger, R"(Error during command execution, "{}")", e.what());
+	LOG_CONERR(logger, R"(Error during command execution, "{}")", e.what());
 }
 
 void handle_help_command(const commands::Arguments& arguments,
                          const Registries& registries,
                          log::Logger& logger) {
 	if(arguments.empty()) {
-		LOG_CONSOLE_ASYNC(
+		LOG_CONSOLE(
 			logger,
 			R"(Type "help "<command>" (quoted) to display command usage or press tab for autocompletion)"
 		);
@@ -153,10 +153,10 @@ void handle_help_command(const commands::Arguments& arguments,
 	const auto result = registry.find(token_view);
 
 	if(result.command) {
-		LOG_CONSOLE_ASYNC(logger, "Usage: {} {}", command, result.command->usage_string());
-		LOG_CONSOLE_ASYNC(logger, "Description: {}", result.command->description());
+		LOG_CONSOLE(logger, "Usage: {} {}", command, result.command->usage_string());
+		LOG_CONSOLE(logger, "Description: {}", result.command->description());
 	} else {
-		LOG_CONSOLE_ERROR_ASYNC(logger, R"(Command "{}" not found)", command);
+		LOG_CONERR(logger, R"(Command "{}" not found)", command);
 	}
 }
 
@@ -165,7 +165,7 @@ void handle_cls_command(log::Logger& logger) {
 	auto sinks = logger.fetch_sink(log::CommandSink::sink_name);
 
 	if(sinks.empty()) {
-		LOG_ERROR_SYNC(logger, "Could not locate a command sink, cannot execute command");
+		SLOG_ERROR(logger, "Could not locate a command sink, cannot execute command");
 	}
 
 	assert(sinks.size() == 1 && "multiple command sinks?");
@@ -307,10 +307,10 @@ void register_command_handlers(Registries& registries, log::Logger& logger) {
 	auto sinks = logger.fetch_sink(log::CommandSink::sink_name);
 
 	if(sinks.empty()) {
-		LOG_INFO_SYNC(logger, "Console commands disabled, no suitable logging sink found");
+		SLOG_INFO(logger, "Console commands disabled, no suitable logging sink found");
 		return;
 	} else if(sinks.size() > 1) {
-		LOG_ERROR_SYNC(logger, "Console commands disabled, multiple command logging sinks found");
+		SLOG_ERROR(logger, "Console commands disabled, multiple command logging sinks found");
 		return;
 	}
 

--- a/src/fusion/main.cpp
+++ b/src/fusion/main.cpp
@@ -69,7 +69,7 @@ int main(int argc, const char* argv[]) try {
 	};
 
 	const auto ret = launch(args, logger);
-	LOG_INFO_SYNC(logger, "{} terminated", app_name);
+	SLOG_INFO(logger, "{} terminated", app_name);
 	return ret;
 } catch(const std::exception& e) {
 	std::cerr << e.what();
@@ -89,7 +89,7 @@ void service_start(const std::string& service, log::Logger& logger) {
 	auto idx = string_to_idx(service);
 
 	if(idx == ServiceIndex::service_invalid) {
-		LOG_CONSOLE_ERROR_ASYNC(logger, "Unrecognised service name, {}", service);
+		LOG_CONERR(logger, "Unrecognised service name, {}", service);
 		return;
 	}
 
@@ -97,7 +97,7 @@ void service_start(const std::string& service, log::Logger& logger) {
 		auto& [_, runner] = *it;
 
 		if(!runner.is_stopped()) {
-			LOG_CONSOLE_ERROR_ASYNC(logger, "Service ({}) is already running", service);
+			LOG_CONERR(logger, "Service ({}) is already running", service);
 			return;
 		}
 	}
@@ -106,7 +106,7 @@ void service_start(const std::string& service, log::Logger& logger) {
 	const auto params = create_params(&registry);
 	auto runner = create_runner(idx, params);
 
-	LOG_CONSOLE_ASYNC(logger, "Starting {} service...", service);
+	LOG_CONSOLE(logger, "Starting {} service...", service);
 	runner.run();
 	runners.insert_or_assign(service, std::move(runner));
 }
@@ -115,20 +115,20 @@ void service_stop(const std::string& service, log::Logger& logger) {
 	auto it = runners.find(service);
 
 	if(it == runners.end()) {
-		LOG_CONSOLE_ERROR_ASYNC(logger, R"(Service "{}" not found or not running)", service);
+		LOG_CONERR(logger, R"(Service "{}" not found or not running)", service);
 		return;
 	}
 
 	auto& [_, runner] = *it;
 
 	if(runner.is_stopped()) {
-		LOG_CONSOLE_ERROR_ASYNC(logger, "Service is not running", service);
+		LOG_CONERR(logger, "Service is not running", service);
 		return;
 	}
 
-	LOG_CONSOLE_ASYNC(logger, "Waiting for {} service to stop...", service);
+	LOG_CONSOLE(logger, "Waiting for {} service to stop...", service);
 	runner.stop();
-	LOG_CONSOLE_ASYNC(logger, "Service stopped");
+	LOG_CONSOLE(logger, "Service stopped");
 
 	destroy_service(runner.context());
 	runners.erase(it);
@@ -218,7 +218,7 @@ int launch(const opts::variables_map& args, log::Logger& logger) try {
 	boost::asio::signal_set signals(ioc, SIGINT, SIGTERM);
 
 	signals.async_wait([&](auto error, auto signal) {
-		LOG_DEBUG_SYNC(logger, "Received signal {}({})", utility::sig_str(signal), signal);
+		SLOG_DEBUG(logger, "Received signal {}({})", utility::sig_str(signal), signal);
 		signals.clear();
 		stop_services();
 	});
@@ -226,7 +226,7 @@ int launch(const opts::variables_map& args, log::Logger& logger) try {
 	ioc.run();
 	return EXIT_SUCCESS;
 } catch(const std::exception& e) {
-	LOG_FATAL_SYNC(logger, e.what());
+	SLOG_FATAL(logger, e.what());
 	return EXIT_FAILURE;
 }
 

--- a/src/libs/logger/include/logger/HelperMacros.h
+++ b/src/libs/logger/include/logger/HelperMacros.h
@@ -14,82 +14,82 @@ inline auto& log_deref(auto& x) { return x; }
 inline auto& log_deref(auto* x) { return *x; }
 
 #if !defined(NO_LOGGING) && !defined(NO_TRACE_LOGGING)
-	#define LOG_TRACE(logger) \
+	#define LOG_TRACE_STREAM(logger) \
 		if(logger->severity() <= ember::log::Severity::trace) \
 			log_deref(logger) << ember::log::Severity::trace
 #else
-	#define LOG_TRACE(logger) \
+	#define LOG_TRACE_STREAM(logger) \
 		if(false) \
 			log_deref(logger)
 #endif
 
 #if !defined(NO_LOGGING) && !defined(NO_DEBUG_LOGGING)
-	#define LOG_DEBUG(logger) \
+	#define LOG_DEBUG_STREAM(logger) \
 		if(logger->severity() <= ember::log::Severity::debug) \
 			log_deref(logger) << ember::log::Severity::debug
 #else
-	#define LOG_DEBUG(logger) \
+	#define LOG_DEBUG_STREAM(logger) \
 		if(false) \
 			log_deref(logger)
 #endif
 
 #if !defined(NO_LOGGING) && !defined(NO_INFO_LOGGING)
-	#define LOG_INFO(logger) \
+	#define LOG_INFO_STREAM(logger) \
 		if(logger->severity() <= ember::log::Severity::info) \
 			log_deref(logger) << ember::log::Severity::info
 #else
-	#define LOG_INFO(logger) \
+	#define LOG_INFO_STREAM(logger) \
 		if(false) \
 			log_deref(logger)
 #endif
 
 #if !defined(NO_LOGGING) && !defined(NO_WARN_LOGGING)
-	#define LOG_WARN(logger) \
+	#define LOG_WARN_STREAM(logger) \
 	if(logger->severity() <= ember::log::Severity::warn) \
 			log_deref(logger) << ember::log::Severity::warn
 #else
-	#define LOG_WARN(logger) \
+	#define LOG_WARN_STREAM(logger) \
 		if(false) \
 			log_deref(logger)
 #endif
 
 #if !defined(NO_LOGGING) && !defined(NO_ERROR_LOGGING)
-	#define LOG_ERROR(logger) \
+	#define LOG_ERROR_STREAM(logger) \
 		if(logger->severity() <= ember::log::Severity::error) \
 			log_deref(logger) << ember::log::Severity::error
 #else
-	#define LOG_ERROR(logger) \
+	#define LOG_ERROR_STREAM(logger) \
 		if(false) \
 			log_deref(logger)
 #endif
 
 
 #if !defined(NO_LOGGING) && !defined(NO_FATAL_LOGGING)
-	#define LOG_FATAL(logger) \
+	#define LOG_FATAL_STREAM(logger) \
 		if(logger->severity() <= ember::log::Severity::fatal) \
 			log_deref(logger) << ember::log::Severity::fatal
 #else
-	#define LOG_FATAL(logger) \
+	#define LOG_FATAL_STREAM(logger) \
 		if(false) \
 			log_deref(logger)
 #endif
 
 #if !defined(NO_LOGGING) && !defined(NO_CONSOLE_LOGGING)
-#define LOG_CONSOLE(logger) \
+#define LOG_CONSOLE_STREAM(logger) \
 		if(logger->severity() <= ember::log::Severity::console) \
 			log_deref(logger) << ember::log::Severity::console
 #else
-#define LOG_CONSOLE(logger) \
+#define LOG_CONSOLE_STREAM(logger) \
 		if(false) \
 			log_deref(logger)
 #endif
 
 #if !defined(NO_LOGGING) && !defined(NO_CONSOLE_LOGGING)
-#define LOG_CONSOLE_ERR(logger) \
+#define LOG_CONERR_STREAM(logger) \
 		if(logger->severity() <= ember::log::Severity::console_error) \
 			log_deref(logger) << ember::log::Severity::console_error
 #else
-#define LOG_CONSOLE_ERR(logger) \
+#define LOG_CONERR_STREAM(logger) \
 		if(false) \
 			log_deref(logger)
 #endif
@@ -176,25 +176,25 @@ inline auto& log_deref(auto* x) { return *x; }
 #endif
 
 #define LOG_TRACE_GLOB \
-	LOG_TRACE(ember::log::global_logger())
+	LOG_TRACE_STREAM(ember::log::global_logger())
 
 #define LOG_DEBUG_GLOB \
-	LOG_DEBUG(ember::log::global_logger())
+	LOG_DEBUG_STREAM(ember::log::global_logger())
 
 #define LOG_INFO_GLOB \
-	LOG_INFO(ember::log::global_logger())
+	LOG_INFO_STREAM(ember::log::global_logger())
 
 #define LOG_WARN_GLOB \
-	LOG_WARN(ember::log::global_logger())
+	LOG_WARN_STREAM(ember::log::global_logger())
 
 #define LOG_ERROR_GLOB \
-	LOG_ERROR(ember::log::global_logger())
+	LOG_ERROR_STREAM(ember::log::global_logger())
 
 #define LOG_FATAL_GLOB \
-	LOG_FATAL(ember::log::global_logger())
+	LOG_FATAL_STREAM(ember::log::global_logger())
 
 #define LOG_CONSOLE_GLOB \
-	LOG_CONSOLE(ember::log::global_logger())
+	LOG_CONSOLE_STREAM(ember::log::global_logger())
 
 #define LOG_TRACE_FILTER_GLOB(filter) \
 	LOG_TRACE_FILTER(ember::log::global_logger(), filter)
@@ -224,146 +224,146 @@ inline auto& log_deref(auto* x) { return *x; }
 #define LOG_SYNC  ember::log::flush_sync
 
 #if !defined(NO_LOGGING) && !defined(NO_TRACE_LOGGING)
-	#define LOG_TRACE_ASYNC(logger, fmt_str, ...) \
+	#define LOG_TRACE(logger, fmt_str, ...) \
 		if(logger->severity() <= ember::log::Severity::trace) \
 			logger->fmt_write<true>(ember::log::Severity::trace, fmt_str __VA_OPT__(,) __VA_ARGS__);
 #else
-	#define LOG_TRACE_ASYNC(logger, fmt_str, ...) \
+	#define LOG_TRACE(logger, fmt_str, ...) \
 		if(false);
 #endif
 
 #if !defined(NO_LOGGING) && !defined(NO_DEBUG_LOGGING)
-	#define LOG_DEBUG_ASYNC(logger, fmt_str, ...) \
+	#define LOG_DEBUG(logger, fmt_str, ...) \
 		if(logger->severity() <= ember::log::Severity::debug) \
 			logger->fmt_write<true>(ember::log::Severity::debug, fmt_str __VA_OPT__(,) __VA_ARGS__);
 #else
-	#define LOG_DEBUG_ASYNC(logger, fmt_str, ...) \
+	#define LOG_DEBUG(logger, fmt_str, ...) \
 		if(false);
 #endif
 
 #if !defined(NO_LOGGING) && !defined(NO_INFO_LOGGING)
-	#define LOG_INFO_ASYNC(logger, fmt_str, ...) \
+	#define LOG_INFO(logger, fmt_str, ...) \
 		if(logger->severity() <= ember::log::Severity::info) \
 			logger->fmt_write<true>(ember::log::Severity::info, fmt_str __VA_OPT__(,) __VA_ARGS__);
 #else
-	#define LOG_INFO_ASYNC(logger, fmt_str, ...) \
+	#define LOG_INFO(logger, fmt_str, ...) \
 		if(false);
 #endif
 
 #if !defined(NO_LOGGING) && !defined(NO_WARN_LOGGING)
-	#define LOG_WARN_ASYNC(logger, fmt_str, ...) \
+	#define LOG_WARN(logger, fmt_str, ...) \
 		if(logger->severity() <= ember::log::Severity::warn) \
 			logger->fmt_write<true>(ember::log::Severity::warn, fmt_str __VA_OPT__(,) __VA_ARGS__);
 #else
-	#define LOG_WARN_ASYNC(logger, fmt_str, ...) \
+	#define LOG_WARN(logger, fmt_str, ...) \
 		if(false);
 #endif
 
 #if !defined(NO_LOGGING) && !defined(NO_ERROR_LOGGING)
-	#define LOG_ERROR_ASYNC(logger, fmt_str, ...) \
+	#define LOG_ERROR(logger, fmt_str, ...) \
 		if(logger->severity() <= ember::log::Severity::error) \
 			logger->fmt_write<true>(ember::log::Severity::error, fmt_str __VA_OPT__(,) __VA_ARGS__);
 #else
-	#define LOG_ERROR_ASYNC(logger, fmt_str, ...) \
+	#define LOG_ERROR(logger, fmt_str, ...) \
 		if(false);
 #endif
 
 #if !defined(NO_LOGGING) && !defined(NO_FATAL_LOGGING)
-	#define LOG_FATAL_ASYNC(logger, fmt_str, ...) \
+	#define LOG_FATAL(logger, fmt_str, ...) \
 		if(logger->severity() <= ember::log::Severity::fatal) \
 			logger->fmt_write<true>(ember::log::Severity::fatal, fmt_str __VA_OPT__(,) __VA_ARGS__);
 #else
-	#define LOG_FATAL_ASYNC(logger, fmt_str, ...) \
+	#define LOG_FATAL(logger, fmt_str, ...) \
 		if(false);
 #endif
 
 #if !defined(NO_LOGGING) && !defined(NO_CONSOLE_LOGGING)
-#define LOG_CONSOLE_ASYNC(logger, fmt_str, ...) \
+#define LOG_CONSOLE(logger, fmt_str, ...) \
 		if(logger->severity() <= ember::log::Severity::console) \
 			logger->fmt_write<true>(ember::log::Severity::console, fmt_str __VA_OPT__(,) __VA_ARGS__);
 #else
-#define LOG_CONSOLE_ASYNC(logger, fmt_str, ...) \
+#define LOG_CONSOLE(logger, fmt_str, ...) \
 		if(false);
 #endif
 
 #if !defined(NO_LOGGING) && !defined(NO_CONSOLE_LOGGING)
-#define LOG_CONSOLE_ERROR_ASYNC(logger, fmt_str, ...) \
+#define LOG_CONERR(logger, fmt_str, ...) \
 		if(logger->severity() <= ember::log::Severity::console_error) \
 			logger->fmt_write<true>(ember::log::Severity::console_error, fmt_str __VA_OPT__(,) __VA_ARGS__);
 #else
-#define LOG_CONSOLE_ERROR_ASYNC(logger, fmt_str, ...) \
+#define LOG_CONERR(logger, fmt_str, ...) \
 		if(false);
 #endif
 
 #if !defined(NO_LOGGING) && !defined(NO_TRACE_LOGGING)
-	#define LOG_TRACE_SYNC(logger, fmt_str, ...) \
+	#define SLOG_TRACE(logger, fmt_str, ...) \
 		if(logger->severity() <= ember::log::Severity::trace) \
 			logger->fmt_write<false>(ember::log::Severity::trace, fmt_str __VA_OPT__(,) __VA_ARGS__);
 #else
-	#define LOG_TRACE_SYNC(logger, fmt_str, ...) \
+	#define SLOG_TRACE(logger, fmt_str, ...) \
 		if(false);
 #endif
 
 #if !defined(NO_LOGGING) && !defined(NO_DEBUG_LOGGING)
-	#define LOG_DEBUG_SYNC(logger, fmt_str, ...) \
+	#define SLOG_DEBUG(logger, fmt_str, ...) \
 		if(logger->severity() <= ember::log::Severity::debug) \
 			logger->fmt_write<false>(ember::log::Severity::debug, fmt_str __VA_OPT__(,) __VA_ARGS__);
 #else
-	#define LOG_DEBUG_SYNC(logger, fmt_str, ...) \
+	#define SLOG_DEBUG(logger, fmt_str, ...) \
 		if(false);
 #endif
 
 #if !defined(NO_LOGGING) && !defined(NO_INFO_LOGGING)
-	#define LOG_INFO_SYNC(logger, fmt_str, ...) \
+	#define SLOG_INFO(logger, fmt_str, ...) \
 		if(logger->severity() <= ember::log::Severity::info) \
 			logger->fmt_write<false>(ember::log::Severity::info, fmt_str __VA_OPT__(,) __VA_ARGS__);
 #else
-	#define LOG_INFO_SYNC(logger, fmt_str, ...) \
+	#define SLOG_INFO(logger, fmt_str, ...) \
 		if(false);
 #endif
 
 #if !defined(NO_LOGGING) && !defined(NO_WARN_LOGGING)
-	#define LOG_WARN_SYNC(logger, fmt_str, ...) \
+	#define SLOG_WARN(logger, fmt_str, ...) \
 		if(logger->severity() <= ember::log::Severity::warn) \
 			logger->fmt_write<false>(ember::log::Severity::warn, fmt_str __VA_OPT__(,) __VA_ARGS__);
 #else
-	#define LOG_WARN_SYNC(logger, fmt_str, ...) \
+	#define SLOG_WARN(logger, fmt_str, ...) \
 		if(false);
 #endif
 
 #if !defined(NO_LOGGING) && !defined(NO_ERROR_LOGGING)
-	#define LOG_ERROR_SYNC(logger, fmt_str, ...) \
+	#define SLOG_ERROR(logger, fmt_str, ...) \
 		if(logger->severity() <= ember::log::Severity::error) \
 			logger->fmt_write<false>(ember::log::Severity::error, fmt_str __VA_OPT__(,) __VA_ARGS__);
 #else
-	#define LOG_ERROR_SYNC(logger, fmt_str, ...) \
+	#define SLOG_ERROR(logger, fmt_str, ...) \
 		if(false);
 #endif
 
 #if !defined(NO_LOGGING) && !defined(NO_FATAL_LOGGING)
-	#define LOG_FATAL_SYNC(logger, fmt_str, ...) \
+	#define SLOG_FATAL(logger, fmt_str, ...) \
 		if(logger->severity() <= ember::log::Severity::fatal) \
 			logger->fmt_write<false>(ember::log::Severity::fatal, fmt_str __VA_OPT__(,) __VA_ARGS__);
 #else
-	#define LOG_FATAL_SYNC(logger, fmt_str, ...) \
+	#define SLOG_FATAL(logger, fmt_str, ...) \
 		if(false);
 #endif
 
 #if !defined(NO_LOGGING) && !defined(NO_CONSOLE_LOGGING)
-#define LOG_CONSOLE_SYNC(logger, fmt_str, ...) \
+#define SLOG_CONSOLE(logger, fmt_str, ...) \
 		if(logger->severity() <= ember::log::Severity::console) \
 			logger->fmt_write<false>(ember::log::Severity::console, fmt_str __VA_OPT__(,) __VA_ARGS__);
 #else
-#define LOG_CONSOLE_SYNC(logger, fmt_str, ...) \
+#define SLOG_CONSOLE(logger, fmt_str, ...) \
 		if(false);
 #endif
 
 #if !defined(NO_LOGGING) && !defined(NO_CONSOLE_LOGGING)
-#define LOG_CONSOLE_ERROR_SYNC(logger, fmt_str, ...) \
+#define SLOG_CONERR(logger, fmt_str, ...) \
 		if(logger->severity() <= ember::log::Severity::console_error) \
 			logger->fmt_write<false>(ember::log::Severity::console_error, fmt_str __VA_OPT__(,) __VA_ARGS__);
 #else
-#define LOG_CONSOLE_ERROR_SYNC(logger, fmt_str, ...) \
+#define SLOG_CONERR(logger, fmt_str, ...) \
 		if(false);
 #endif
 

--- a/src/libs/nsd/src/NSD.cpp
+++ b/src/libs/nsd/src/NSD.cpp
@@ -33,19 +33,19 @@ void NetworkServiceDiscovery::connect() {
 }
 
 void NetworkServiceDiscovery::on_link_up(const spark::Link& link) {
-	LOG_TRACE_ASYNC(logger_, "Established connection to NSD service");
+	LOG_TRACE(logger_, "Established connection to NSD service");
 	link_ = link;
 	connected_ = true;
 	retry_interval_ = RETRY_INTERVAL_MIN;
 }
 
 void NetworkServiceDiscovery::on_link_down(const spark::Link& link) {
-	LOG_TRACE_ASYNC(logger_, "Lost connection to NSD service");
+	LOG_TRACE(logger_, "Lost connection to NSD service");
 	connected_ = false;
 }
 
 void NetworkServiceDiscovery::connect_failed(const std::string_view ip, std::uint16_t port) {
-	LOG_WARN_ASYNC(logger_, "Unable to connect to NSD service, retrying in {}", retry_interval_);
+	LOG_WARN(logger_, "Unable to connect to NSD service, retrying in {}", retry_interval_);
 
 	timer_.expires_after(retry_interval_);
 	increase_interval();

--- a/src/libs/shared/shared/utility/CommandHelpers.cpp
+++ b/src/libs/shared/shared/utility/CommandHelpers.cpp
@@ -23,10 +23,10 @@
 namespace ember::utility {
 
 void log_subcommands(log::Logger& logger, const std::string& path, const commands::CommandMap& subcommands) {
-	LOG_CONSOLE_ASYNC(logger, R"(Available subcomands for "{}": )", path);
+	LOG_CONSOLE(logger, R"(Available subcomands for "{}": )", path);
 
 	for(auto& subcommand : subcommands | std::views::values) {
-		LOG_CONSOLE_ASYNC(logger, "{} : {}", subcommand->name(), subcommand->description());
+		LOG_CONSOLE(logger, "{} : {}", subcommand->name(), subcommand->description());
 	}
 }
 
@@ -38,19 +38,19 @@ void handle_command_result(commands::Result result,
         case commands::Result::missing_args:
 			[[fallthrough]];
         case commands::Result::too_many_args:
-			LOG_CONSOLE_ERROR_ASYNC(logger, "Usage: {} {}", path, command.usage_string());
+			LOG_CONERR(logger, "Usage: {} {}", path, command.usage_string());
             break;
         case commands::Result::subcommands:
 			log_subcommands(logger, path, command.commands());
             break;
         case commands::Result::unavailable:
-			LOG_CONSOLE_ERROR_ASYNC(logger, R"(Command "{}" is currently unavailable.)", path);
+			LOG_CONERR(logger, R"(Command "{}" is currently unavailable.)", path);
             break;
 		case commands::Result::invalid_types:
-			LOG_CONSOLE_ERROR_ASYNC(logger, R"(Bad argument types when attempting to execute "{}")", path);
+			LOG_CONERR(logger, R"(Bad argument types when attempting to execute "{}")", path);
 			break;
         default:
-			LOG_CONSOLE_ERROR_ASYNC(logger, R"(An unhandled error occurred while executing "{}")", path);
+			LOG_CONERR(logger, R"(An unhandled error occurred while executing "{}")", path);
             break;
     }
 }
@@ -92,7 +92,7 @@ void execute_command(const std::string_view input, const commands::Registry& reg
 	const auto search = registry.find(tokens);
 
 	if(!search.command) {
-		LOG_CONSOLE_ERROR_ASYNC(
+		LOG_CONERR(
 			logger,
 			R"(Command "{}" not found)",
 			tokens.front()
@@ -109,7 +109,7 @@ void execute_command(const std::string_view input, const commands::Registry& reg
 	 * trigger from here. This check is only for user feedback, it is not required for correct behaviour.
 	 */
 	if(arguments.size() > search.command->argument_count()) {
-		LOG_CONSOLE_ERROR_ASYNC(
+		LOG_CONERR(
 			logger,
 			R"(Too many arguments passed to "{}" (takes {}, got {}))",
 			tokens.front(),
@@ -134,18 +134,18 @@ void execute_command(const std::string_view input, const commands::Registry& reg
 		handle_command_result(result, path, *search.command, logger);
 	}
 } catch(const commands::parse_error& e) {
-	LOG_CONSOLE_ERROR_ASYNC(logger, R"(Error parsing command arguments, "{}")", e.what());
+	LOG_CONERR(logger, R"(Error parsing command arguments, "{}")", e.what());
 } catch(const boost::bad_lexical_cast&) {
-	LOG_CONSOLE_ERROR_ASYNC(logger, R"(Unable to execute command, invalid argument types provided)");
+	LOG_CONERR(logger, R"(Unable to execute command, invalid argument types provided)");
 } catch(const std::exception& e) {
-	LOG_CONSOLE_ERROR_ASYNC(logger, R"(Error during command execution, "{}")", e.what());
+	LOG_CONERR(logger, R"(Error during command execution, "{}")", e.what());
 }
 
 void handle_help_command(const commands::Arguments& arguments,
                          const commands::Registry& registry,
                          log::Logger& logger) {
 	if(arguments.empty()) {
-		LOG_CONSOLE_ASYNC(
+		LOG_CONSOLE(
 			logger,
 			R"(Type "help "<command>" (quoted) to display command usage or press tab for autocompletion)"
 		);
@@ -158,10 +158,10 @@ void handle_help_command(const commands::Arguments& arguments,
 	const auto result = registry.find(tokens);
 
 	if(result.command) {
-		LOG_CONSOLE_ASYNC(logger, "Usage: {} {}", command, result.command->usage_string());
-		LOG_CONSOLE_ASYNC(logger, "Description: {}", result.command->description());
+		LOG_CONSOLE(logger, "Usage: {} {}", command, result.command->usage_string());
+		LOG_CONSOLE(logger, "Description: {}", result.command->description());
 	} else {
-		LOG_CONSOLE_ERROR_ASYNC(logger, R"(Command "{}" not found)", command);
+		LOG_CONERR(logger, R"(Command "{}" not found)", command);
 	}
 }
 
@@ -180,7 +180,7 @@ void handle_cls_command(log::Logger& logger) {
 	auto sinks = logger.fetch_sink(log::CommandSink::sink_name);
 
 	if(sinks.empty()) {
-		LOG_ERROR_SYNC(logger, "Could not locate a command sink, cannot execute command");
+		SLOG_ERROR(logger, "Could not locate a command sink, cannot execute command");
 	}
 
 	assert(sinks.size() == 1 && "multiple command sinks?");
@@ -213,10 +213,10 @@ void register_command_handlers(commands::Registry& registry, log::Logger& logger
 	auto sinks = logger.fetch_sink(log::CommandSink::sink_name);
 
 	if(sinks.empty()) {
-		LOG_INFO_SYNC(logger, "Console commands disabled, no suitable logging sink found");
+		SLOG_INFO(logger, "Console commands disabled, no suitable logging sink found");
 		return;
 	} else if(sinks.size() > 1) {
-		LOG_ERROR_SYNC(logger, "Console commands disabled, multiple command logging sinks found");
+		SLOG_ERROR(logger, "Console commands disabled, multiple command logging sinks found");
 		return;
 	}
 

--- a/src/libs/shared/shared/utility/STUN.h
+++ b/src/libs/shared/shared/utility/STUN.h
@@ -34,26 +34,26 @@ inline void log_stun_result(stun::Client& client,
                             const std::uint16_t port,
                             log::Logger& logger) {
 	if(!result) {
-		LOG_ERROR_SYNC(logger, "[stun] Query failed ({})", stun::to_string(result.error().reason));
+		SLOG_ERROR(logger, "[stun] Query failed ({})", stun::to_string(result.error().reason));
 		return;
 	}
 
 	const auto& ip = stun::extract_ip_to_string(*result);
-	LOG_INFO_SYNC(logger, "[stun] Binding request succeeded, external address is {}", ip);
+	SLOG_INFO(logger, "[stun] Binding request succeeded, external address is {}", ip);
 
 	const auto nat = client.nat_present().get();
 
 	if(!nat) {
-		LOG_WARN_SYNC(logger, "[stun] Unable to determine if gateway is behind NAT ({})",
+		SLOG_WARN(logger, "[stun] Unable to determine if gateway is behind NAT ({})",
 		                      stun::to_string(nat.error().reason));
 		return;
 	}
 
 	if(*nat) {
-		LOG_INFO_SYNC(logger, "[stun] Service appears to be behind NAT, "
+		SLOG_INFO(logger, "[stun] Service appears to be behind NAT, "
 		                      "forward port {} for external access", port);
 	} else {
-		LOG_INFO_SYNC(logger, "[stun] Service does not appear to be behind NAT - "
+		SLOG_INFO(logger, "[stun] Service does not appear to be behind NAT - "
 		                      "server is available online (firewall rules permitting)");
 	}
 }

--- a/src/libs/spark/src/Connection.cpp
+++ b/src/libs/spark/src/Connection.cpp
@@ -79,7 +79,7 @@ asio::awaitable<std::size_t> Connection::read_until(const std::size_t offset,
 }
 
 void Connection::buffer_resize(const std::uint32_t size) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	if(size > MAXIMUM_BUFFER_SIZE) {
 		const auto log_msg = std::format(
@@ -89,7 +89,7 @@ void Connection::buffer_resize(const std::uint32_t size) {
 		throw exception(log_msg);
 	}
 
-	LOG_TRACE_ASYNC(logger_, "Resizing RPC buffer to {}b", size);
+	LOG_TRACE(logger_, "Resizing RPC buffer to {}b", size);
 	buffer_.resize(size);
 }
 
@@ -121,7 +121,7 @@ asio::awaitable<void> Connection::begin_receive(ReceiveHandler handler) try {
 		handler(view);
 	}
 } catch(const std::exception& e) {
-	LOG_WARN(logger_) << e.what() << LOG_ASYNC;
+	LOG_WARN(logger_, e.what());
 	close();
 }
 
@@ -154,12 +154,12 @@ asio::awaitable<void> Connection::send(Message& msg) {
 
 // start full-duplex send/receive
 void Connection::start(ReceiveHandler handler) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 	asio::co_spawn(strand_, begin_receive(handler), asio::detached);
 }
 
 void Connection::close() {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	socket_.close();
 

--- a/src/libs/spark/src/RemotePeer.cpp
+++ b/src/libs/spark/src/RemotePeer.cpp
@@ -39,7 +39,7 @@ void RemotePeer::send(Message&& msg) {
 }
 
 void RemotePeer::receive(std::span<const std::uint8_t> data) {
-	LOG_TRACE(log_) << log_func << LOG_ASYNC;
+	LOG_TRACE(log_, log_func);
 
 	spark::io::BufferAdaptor adaptor(data);
 	spark::io::BinaryStream stream(adaptor);
@@ -48,7 +48,7 @@ void RemotePeer::receive(std::span<const std::uint8_t> data) {
 
 	if(header.read_from_stream(stream) != MessageHeader::State::ok
 	   || header.size <= stream.total_read()) {
-		LOG_WARN_ASYNC(log_, "[spark] Bad message from {}", conn_->address());
+		LOG_WARN(log_, "[spark] Bad message from {}", conn_->address());
 		return;
 	}
 
@@ -63,11 +63,11 @@ void RemotePeer::receive(std::span<const std::uint8_t> data) {
 }
 
 void RemotePeer::handle_open_channel_response(const core::OpenChannelResponse& msg) {
-	LOG_TRACE(log_) << log_func << LOG_ASYNC;
+	LOG_TRACE(log_, log_func);
 
 	if(msg.result() != core::Result::ok) {
 		auto& channel = channels_[msg.requested_id()];
-		LOG_ERROR_ASYNC(log_, "[spark] Remote peer could not open channel ({}:{})",
+		LOG_ERROR(log_, "[spark] Remote peer could not open channel ({}:{})",
 		                channel->handler()->type(), msg.requested_id());
 		channels_[msg.requested_id()].reset();
 		return;
@@ -78,14 +78,14 @@ void RemotePeer::handle_open_channel_response(const core::OpenChannelResponse& m
 	auto& channel = channels_[id];
 
 	if(id == 0) {
-		LOG_ERROR_ASYNC(log_, "[spark] Reserved channel ID returned by {}", remote_banner_);
+		LOG_ERROR(log_, "[spark] Reserved channel ID returned by {}", remote_banner_);
 		channels_[msg.requested_id()].reset();
 		return;
 	}
 
 	if(msg.actual_id() != msg.requested_id()) {
 		if(channel) {
-			LOG_ERROR_ASYNC(log_, "[spark] Channel open ({}) failed due to ID collision",
+			LOG_ERROR(log_, "[spark] Channel open ({}) failed due to ID collision",
 			                msg.actual_id());
 			send_close_channel(msg.actual_id());
 			channels_[msg.requested_id()].reset();
@@ -105,12 +105,12 @@ void RemotePeer::handle_open_channel_response(const core::OpenChannelResponse& m
 
 	channel->open();
 
-	LOG_DEBUG_ASYNC(log_, "[spark] Remote channel open, {}:{}",
+	LOG_DEBUG(log_, "[spark] Remote channel open, {}:{}",
 	                channel->handler()->name(), msg.actual_id());
 }
 
 void RemotePeer::send_close_channel(const std::uint8_t id) {
-	LOG_TRACE(log_) << log_func << LOG_ASYNC;
+	LOG_TRACE(log_, log_func);
 
 	core::CloseChannelT body {
 		.channel = id
@@ -147,19 +147,19 @@ Handler* RemotePeer::find_handler(const core::OpenChannel& msg) {
 }
 
 void RemotePeer::handle_open_channel(const core::OpenChannel& msg) {
-	LOG_TRACE(log_) << log_func << LOG_ASYNC;
+	LOG_TRACE(log_, log_func);
 
 	auto handler = find_handler(msg);
 
 	if(!handler) {
-		LOG_DEBUG_ASYNC(log_, "[spark] Requested service handler ({}) does not exist",
+		LOG_DEBUG(log_, "[spark] Requested service handler ({}) does not exist",
 		                msg.service_type()->str());
 		open_channel_response(core::Result::error_unk, 0, msg.id());
 		return;
 	}
 
 	if(msg.id() == 0 || msg.id() >= channels_.size()) {
-		LOG_DEBUG_ASYNC(log_, "[spark] Bad channel ID ({}) specified", msg.id());
+		LOG_DEBUG(log_, "[spark] Bad channel ID ({}) specified", msg.id());
 		open_channel_response(core::Result::error_unk, 0, msg.id());
 		return;
 	}
@@ -168,7 +168,7 @@ void RemotePeer::handle_open_channel(const core::OpenChannel& msg) {
 
 	if(channels_[id]) {
 		if(id = next_empty_channel(); id == 0) {
-			LOG_ERROR_ASYNC(log_, "[spark] Exhausted channel IDs");
+			LOG_ERROR(log_, "[spark] Exhausted channel IDs");
 			open_channel_response(core::Result::error_unk, 0, msg.id());
 			return;
 		}
@@ -181,7 +181,7 @@ void RemotePeer::handle_open_channel(const core::OpenChannel& msg) {
 	channel->open();
 	channels_[id] = std::move(channel);
 	open_channel_response(core::Result::ok, id, msg.id());
-	LOG_DEBUG_ASYNC(log_, "[spark] Remote channel open, {}:{}", handler->name(), id);
+	LOG_DEBUG(log_, "[spark] Remote channel open, {}:{}", handler->name(), id);
 }
 
 std::uint8_t RemotePeer::next_empty_channel() {
@@ -219,7 +219,7 @@ void RemotePeer::handle_control_message(std::span<const std::uint8_t> data) {
 	auto fb = core::GetHeader(data.data());
 	
 	if(!fb->Verify(verifier)) {
-		LOG_WARN_ASYNC(log_, "[spark] Bad Flatbuffer message");
+		LOG_WARN(log_, "[spark] Bad Flatbuffer message");
 		return;
 	}
 
@@ -240,7 +240,7 @@ void RemotePeer::handle_control_message(std::span<const std::uint8_t> data) {
 			handle_pong(*fb->message_as_Pong());
 			break;
 		default:
-			LOG_WARN_ASYNC(log_, "[spark] Unknown control message type");
+			LOG_WARN(log_, "[spark] Unknown control message type");
 	}
 }
 
@@ -257,7 +257,7 @@ void RemotePeer::handle_ping(const core::Ping& ping) {
 
 void RemotePeer::handle_pong(const core::Pong& pong) {
 	if(pong.sequence() != ping_sequence_) {
-		LOG_DEBUG_ASYNC(log_, "[spark] Bad pong sequence");
+		LOG_DEBUG(log_, "[spark] Bad pong sequence");
 		return;
 	}
 
@@ -265,33 +265,33 @@ void RemotePeer::handle_pong(const core::Pong& pong) {
 	
 	if(delta > latency_warn_threshold) {
 		const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(delta);
-		LOG_WARN_ASYNC(log_, "[spark] Remote peer is slow to respond {} ({})", ms, remote_banner_);
+		LOG_WARN(log_, "[spark] Remote peer is slow to respond {} ({})", ms, remote_banner_);
 	}
 }
 
 void RemotePeer::handle_close_channel(const core::CloseChannel& msg) {
-	LOG_TRACE(log_) << log_func << LOG_ASYNC;
+	LOG_TRACE(log_, log_func);
 
 	auto id = gsl::narrow<std::uint8_t>(msg.channel());
 
 	if(!channels_[id]) {
-		LOG_WARN_ASYNC(log_, "[spark] Request to close empty channel ({})", id);
+		LOG_WARN(log_, "[spark] Request to close empty channel ({})", id);
 		return;
 	}
 
 	channels_[id]->close();
 	channels_[id].reset();
-	LOG_DEBUG_ASYNC(log_, "[spark] Closed channel ({}), requested by remote peer", id);
+	LOG_DEBUG(log_, "[spark] Closed channel ({}), requested by remote peer", id);
 }
 
 void RemotePeer::handle_channel_message(const MessageHeader& header,
                                         std::span<const std::uint8_t> data) {
-	LOG_TRACE(log_) << log_func << LOG_ASYNC;
+	LOG_TRACE(log_, log_func);
 
 	auto& channel = channels_[header.channel];
 
 	if(!channel || !channel->is_open()) {
-		LOG_WARN_ASYNC(log_, "[spark] Received message for closed channel ({})", header.channel);
+		LOG_WARN(log_, "[spark] Received message for closed channel ({})", header.channel);
 		return;
 	}
 
@@ -312,10 +312,10 @@ void RemotePeer::send_open_channel(std::string name, std::string type, const std
 }
 
 void RemotePeer::open_channel(std::string type, gsl::not_null<Handler*> handler) {
-	LOG_TRACE(log_) << log_func << LOG_ASYNC;
+	LOG_TRACE(log_, log_func);
 
 	const auto id = next_empty_channel();
-	LOG_DEBUG_ASYNC(log_, "[spark] Requesting channel {} for {}", id, type);
+	LOG_DEBUG(log_, "[spark] Requesting channel {} for {}", id, type);
 
 	auto channel = std::make_shared<Channel>(
 		ctx_, id, remote_banner_, handler->name(), handler, conn_, log_

--- a/src/libs/spark/src/Server.cpp
+++ b/src/libs/spark/src/Server.cpp
@@ -44,7 +44,7 @@ Server::Server(boost::asio::io_context& context, std::string_view name,
 }
 
 asio::awaitable<void> Server::listen() {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	while(acceptor_.is_open()) {
 		co_await accept_connection();
@@ -52,7 +52,7 @@ asio::awaitable<void> Server::listen() {
 }
 
 asio::awaitable<void> Server::accept_connection() {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	asio::ip::tcp::socket socket(ctx_);
 	auto [ec] = co_await acceptor_.async_accept(socket, boost::asio::as_tuple);
@@ -64,16 +64,16 @@ asio::awaitable<void> Server::accept_connection() {
 	const auto ep = socket.remote_endpoint(ec);
 
 	if(ec) {
-		LOG_DEBUG_ASYNC(logger_, "[spark] Unable to obtain endpoint, remote peer disconnected");
+		LOG_DEBUG(logger_, "[spark] Unable to obtain endpoint, remote peer disconnected");
 		co_return;
 	}
 
-	LOG_DEBUG_ASYNC(logger_, "[spark] Accepted connection from {}:{}", ep.address().to_string(), ep.port());
+	LOG_DEBUG(logger_, "[spark] Accepted connection from {}:{}", ep.address().to_string(), ep.port());
 	co_await accept(std::move(socket));
 }
 
 asio::awaitable<void> Server::accept(boost::asio::ip::tcp::socket socket) try {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	auto ep = socket.remote_endpoint();
 	const auto key = std::format("{}:{}", ep.address().to_string(), std::to_string(ep.port()));
@@ -85,7 +85,7 @@ asio::awaitable<void> Server::accept(boost::asio::ip::tcp::socket socket) try {
 	auto banner = co_await receive_banner(connection);
 	co_await send_banner(connection, name_);
 
-	LOG_INFO_ASYNC(logger_, "[spark] Connected to {}", banner);
+	LOG_INFO(logger_, "[spark] Connected to {}", banner);
 
 	auto peer = std::make_shared<RemotePeer>(
 		ctx_, std::move(connection), name_, banner, handlers_, logger_
@@ -94,25 +94,25 @@ asio::awaitable<void> Server::accept(boost::asio::ip::tcp::socket socket) try {
 	peer->start();
 	peers_.add(key, std::move(peer));
 } catch(const std::exception& e) {
-	LOG_WARN_ASYNC(logger_, e.what());
+	LOG_WARN(logger_, e.what());
 }
 
 void Server::register_handler(gsl::not_null<Handler*> handler) {
 	handlers_.register_service(handler);
 
-	LOG_TRACE_ASYNC(logger_, "[spark] Registered handler for {}", handler->type());
+	LOG_TRACE(logger_, "[spark] Registered handler for {}", handler->type());
 }
 
 void Server::deregister_handler(gsl::not_null<Handler*> handler) {
 	handlers_.deregister_service(handler);
 	peers_.notify_remove_handler(handler);
 
-	LOG_TRACE_ASYNC(logger_, "[spark] Removed handler for {}", handler->type());
+	LOG_TRACE(logger_, "[spark] Removed handler for {}", handler->type());
 }
 
 asio::awaitable<std::shared_ptr<RemotePeer>>
 Server::connect(const std::string_view host, const std::uint16_t port) try {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	auto results = co_await resolver_.async_resolve(host, std::to_string(port));
 
@@ -128,7 +128,7 @@ Server::connect(const std::string_view host, const std::uint16_t port) try {
 	co_await send_banner(connection, name_);
 	auto banner = co_await receive_banner(connection);
 
-	LOG_INFO_ASYNC(logger_, "[spark] Connected to {}", banner);
+	LOG_INFO(logger_, "[spark] Connected to {}", banner);
 
 	auto peer = std::make_shared<RemotePeer>(
 		ctx_, std::move(connection), name_, banner, handlers_, logger_
@@ -136,13 +136,13 @@ Server::connect(const std::string_view host, const std::uint16_t port) try {
 
 	co_return peer;
 } catch(const std::exception& e) {
-	LOG_DEBUG_ASYNC(logger_, "[spark] Could not connect to {}:{} ({})", host, port, e.what());
+	LOG_DEBUG(logger_, "[spark] Could not connect to {}:{} ({})", host, port, e.what());
 	co_return nullptr;
 }
 
 asio::awaitable<void> Server::try_open(std::string host, std::uint16_t port,
                                      std::string service, gsl::not_null<Handler*> handler) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	const auto key = std::format("{}:{}", host, port);
 
@@ -172,7 +172,7 @@ void Server::connect(const std::string_view host, const std::uint16_t port,
 
 void Server::connect(std::string host, const std::uint16_t port,
                      std::string service, gsl::not_null<Handler*> handler) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	asio::co_spawn(ctx_, try_open(
 		std::move(host), port, std::move(service), handler), asio::detached
@@ -180,7 +180,7 @@ void Server::connect(std::string host, const std::uint16_t port,
 }
 
 asio::awaitable<void> Server::send_banner(Connection& conn, const std::string& banner) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	core::HelloT hello {
 		.description = banner
@@ -194,7 +194,7 @@ asio::awaitable<void> Server::send_banner(Connection& conn, const std::string& b
 
 
 asio::awaitable<std::string> Server::receive_banner(Connection& conn) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	auto msg = co_await conn.receive_msg();
 	spark::io::BufferAdaptor adaptor(msg);
@@ -223,7 +223,7 @@ asio::awaitable<std::string> Server::receive_banner(Connection& conn) {
 
 // todo, need to link down to all channels, error code
 void Server::close_peer(const std::string& key) {
-	//LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	//LOG_TRACE_ASYNC(logger_, log_func);
 	//peers_.remove(key);
 
 	//LOG_DEBUG_FILTER(logger_, LF_SPARK)
@@ -235,7 +235,7 @@ void Server::shutdown() {
 		return;
 	}
 
-	LOG_DEBUG_ASYNC(logger_, "[spark] Service shutting down...");
+	LOG_DEBUG(logger_, "[spark] Service shutting down...");
 
 	acceptor_.close();
 	stopped_ = true;

--- a/src/libs/spark/src/Tracking.cpp
+++ b/src/libs/spark/src/Tracking.cpp
@@ -60,7 +60,7 @@ void Tracking::on_message(const Link& link,
 
 	// request has already expired or never existed
 	if(it == requests_.end()) {
-		LOG_DEBUG_ASYNC(logger_, "[spark] Received invalid or expired tracked response");
+		LOG_DEBUG(logger_, "[spark] Received invalid or expired tracked response");
 		return;
 	}
 

--- a/src/login/AccountClient.cpp
+++ b/src/login/AccountClient.cpp
@@ -21,20 +21,20 @@ AccountClient::AccountClient(spark::Server& spark, log::Logger& logger)
 }
 
 void AccountClient::connect_failed(const std::string_view ip, std::uint16_t port) {
-	LOG_INFO_ASYNC(logger_, "Failed to connect to account service on {}:{}", ip, port);
+	LOG_INFO(logger_, "Failed to connect to account service on {}:{}", ip, port);
 }
 
 void AccountClient::on_link_up(const spark::Link& link) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 	link_ = link;
 }
 
 void AccountClient::on_link_down(const spark::Link& link) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 }
 
 void AccountClient::locate_session(const std::uint32_t account_id, LocateCB cb) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	SessionLookupT msg {
 		.account_id = account_id
@@ -48,7 +48,7 @@ void AccountClient::locate_session(const std::uint32_t account_id, LocateCB cb) 
 void AccountClient::register_session(const std::uint32_t account_id,
                                      const srp6::SessionKey& key,
                                      RegisterCB cb) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	std::vector keyvec(key.t.begin(), key.t.end());
 
@@ -64,7 +64,7 @@ void AccountClient::register_session(const std::uint32_t account_id,
 
 void AccountClient::handle_register_response(std::expected<const RegisterResponse*, spark::Result> res,
                                              const RegisterCB& cb) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	if(!res) {
 		cb(Status::rpc_error);
@@ -76,7 +76,7 @@ void AccountClient::handle_register_response(std::expected<const RegisterRespons
 
 void AccountClient::handle_locate_response(std::expected<const SessionResponse*, spark::Result> res,
                                            const LocateCB& cb) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	if(!res) {
 		cb(Status::rpc_error, {});

--- a/src/login/LoggingCallbacks.h
+++ b/src/login/LoggingCallbacks.h
@@ -21,23 +21,23 @@ inline void forward_log_callback(ports::Severity severity, const std::string_vie
 
 	switch(severity) {
 		case ports::Severity::debug:
-			LOG_DEBUG_ASYNC(logger, fmt, message);
+			LOG_DEBUG(logger, fmt, message);
 			break;
 		case ports::Severity::info:
-			LOG_INFO_ASYNC(logger, fmt, message);
+			LOG_INFO(logger, fmt, message);
 			break;
 		case ports::Severity::warn:
-			LOG_WARN_ASYNC(logger, fmt, message);
+			LOG_WARN(logger, fmt, message);
 			break;
 		case ports::Severity::error:
-			LOG_ERROR_ASYNC(logger, fmt, message);
+			LOG_ERROR(logger, fmt, message);
 			break;
 		case ports::Severity::fatal:
-			LOG_FATAL_ASYNC(logger, fmt, message);
+			LOG_FATAL(logger, fmt, message);
 			break;
 		default:
-			LOG_ERROR_ASYNC(logger, "Unhandled port forward log callback severity");
-			LOG_ERROR_ASYNC(logger, fmt, message);
+			LOG_ERROR(logger, "Unhandled port forward log callback severity");
+			LOG_ERROR(logger, fmt, message);
 	}
 }
 
@@ -47,26 +47,26 @@ inline static void stun_log_callback(stun::Severity severity, stun::Error reason
 
 	switch(severity) {
 		case stun::Severity::trace:
-			LOG_TRACE_SYNC(logger, fmt, reason_str);
+			SLOG_TRACE(logger, fmt, reason_str);
 			break;
 		case stun::Severity::debug:
-			LOG_DEBUG_SYNC(logger, fmt, reason_str);
+			SLOG_DEBUG(logger, fmt, reason_str);
 			break;
 		case stun::Severity::info:
-			LOG_INFO_SYNC(logger, fmt, reason_str);
+			SLOG_INFO(logger, fmt, reason_str);
 			break;
 		case stun::Severity::warn:
-			LOG_WARN_SYNC(logger, fmt, reason_str);
+			SLOG_WARN(logger, fmt, reason_str);
 			break;
 		case stun::Severity::error:
-			LOG_ERROR_SYNC(logger, fmt, reason_str);
+			SLOG_ERROR(logger, fmt, reason_str);
 			break;
 		case stun::Severity::fatal:
-			LOG_FATAL_SYNC(logger, fmt, reason_str);
+			SLOG_FATAL(logger, fmt, reason_str);
 			break;
 		default:
-			LOG_ERROR_ASYNC(logger, "Unhandled STUN log callback severity");
-			LOG_ERROR_SYNC(logger, fmt, reason_str);
+			LOG_ERROR(logger, "Unhandled STUN log callback severity");
+			SLOG_ERROR(logger, fmt, reason_str);
 	}
 }
 
@@ -75,23 +75,23 @@ inline void pool_log_callback(connection_pool::Severity severity, std::string_vi
 
 	switch(severity) {
 		case connection_pool::Severity::debug:
-			LOG_DEBUG_ASYNC(logger, fmt, message);
+			LOG_DEBUG(logger, fmt, message);
 			break;
 		case connection_pool::Severity::info:
-			LOG_INFO_ASYNC(logger, fmt, message);
+			LOG_INFO(logger, fmt, message);
 			break;
 		case connection_pool::Severity::warn:
-			LOG_WARN_ASYNC(logger, fmt, message);
+			LOG_WARN(logger, fmt, message);
 			break;
 		case connection_pool::Severity::error:
-			LOG_ERROR_ASYNC(logger, fmt, message);
+			LOG_ERROR(logger, fmt, message);
 			break;
 		case connection_pool::Severity::fatal:
-			LOG_FATAL_ASYNC(logger, fmt, message);
+			LOG_FATAL(logger, fmt, message);
 			break;
 		default:
-			LOG_ERROR_ASYNC(logger, "Unhandled connection pool log callback severity");
-			LOG_ERROR_ASYNC(logger, fmt, message);
+			LOG_ERROR(logger, "Unhandled connection pool log callback severity");
+			LOG_ERROR(logger, fmt, message);
 	}
 }
 

--- a/src/login/LoginHandler.cpp
+++ b/src/login/LoginHandler.cpp
@@ -30,7 +30,7 @@
 namespace ember {
 
 bool LoginHandler::update_state(const grunt::Packet& packet) try {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	const LoginState prev_state = state_;
 	update_state(LoginState::closed);
@@ -68,19 +68,19 @@ bool LoginHandler::update_state(const grunt::Packet& packet) try {
 		case LoginState::closed:
 			return false;
 		default:
-			LOG_DEBUG_ASYNC(logger_, "Received packet out of sync");
+			LOG_DEBUG(logger_, "Received packet out of sync");
 			return false;
 	}
 
 	return true;
 } catch(const std::exception& e) {
-	LOG_DEBUG(logger_) << e.what() << LOG_ASYNC;
+	LOG_DEBUG(logger_, e.what());
 	update_state(LoginState::closed);
 	return false;
 }
 
 bool LoginHandler::update_state(const Action& action) try {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	const LoginState prev_state = state_;
 	update_state(LoginState::closed);
@@ -107,19 +107,19 @@ bool LoginHandler::update_state(const Action& action) try {
 		case LoginState::closed:
 			return false;
 		default:
-			LOG_WARN_ASYNC(logger_, "Received action out of sync");
+			LOG_WARN(logger_, "Received action out of sync");
 			return false;
 	}
 
 	return true;
 } catch(const std::exception& e) {
-	LOG_DEBUG(logger_) << e.what() << LOG_ASYNC;
+	LOG_DEBUG(logger_, e.what());
 	update_state(LoginState::closed);
 	return false;
 }
 
 void LoginHandler::handle_login_challenge(const grunt::Packet& packet) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	auto& challenge = dynamic_cast<const grunt::client::LoginChallenge&>(packet);
 
@@ -128,17 +128,17 @@ void LoginHandler::handle_login_challenge(const grunt::Packet& packet) {
 	 * but they're close enough that patch transfers will still work
 	 */
 	if(!validate_protocol_version(challenge)) {
-		LOG_DEBUG_ASYNC(logger_, "Unsupported protocol version {} ({})",
+		LOG_DEBUG(logger_, "Unsupported protocol version {} ({})",
 		                challenge.protocol_ver, identifier_);
 	}
 
 	if(challenge.game != grunt::Game::WoW) {
-		LOG_DEBUG_ASYNC(logger_, "Bad game magic ({})", identifier_);
+		LOG_DEBUG(logger_, "Bad game magic ({})", identifier_);
 		update_state(LoginState::closed);
 		return;
 	}
 
-	LOG_DEBUG_ASYNC(logger_, "Challenge: {}, {} ({})", challenge.username,
+	LOG_DEBUG(logger_, "Challenge: {}, {} ({})", challenge.username,
 	                to_string(challenge.version), identifier_);
 
 	const Patcher::PatchLevel level = patcher_.check_version(challenge.version);
@@ -159,7 +159,7 @@ void LoginHandler::handle_login_challenge(const grunt::Packet& packet) {
 }
 
 bool LoginHandler::validate_protocol_version(const grunt::client::LoginChallenge& challenge) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	const auto version = challenge.protocol_ver;
 
@@ -177,7 +177,7 @@ bool LoginHandler::validate_protocol_version(const grunt::client::LoginChallenge
 }
 
 void LoginHandler::fetch_user(grunt::Opcode opcode, const utf8_string& username) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	switch(opcode) {
 		case grunt::Opcode::cmd_auth_logon_challenge:
@@ -196,10 +196,10 @@ void LoginHandler::fetch_user(grunt::Opcode opcode, const utf8_string& username)
 }
 
 void LoginHandler::fetch_session_key(const FetchUserAction& action_res) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	if(!(user_ = action_res.get_result())) {
-		LOG_DEBUG_ASYNC(logger_, "Account not found: {}", action_res.username());
+		LOG_DEBUG(logger_, "Account not found: {}", action_res.username());
 		return;
 	}
 
@@ -209,7 +209,7 @@ void LoginHandler::fetch_session_key(const FetchUserAction& action_res) {
 }
 
 void LoginHandler::reject_client(const GameVersion& version) {
-	LOG_DEBUG_ASYNC(logger_, "Rejecting client version {}", to_string(version));
+	LOG_DEBUG(logger_, "Rejecting client version {}", to_string(version));
 
 	grunt::server::LoginChallenge response;
 	response.result = grunt::Result::fail_version_invalid;
@@ -217,7 +217,7 @@ void LoginHandler::reject_client(const GameVersion& version) {
 }
 
 void LoginHandler::build_login_challenge(grunt::server::LoginChallenge& packet) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	const auto& authenticator = std::get<LoginAuthenticator>(state_data_);
 	const auto& values = authenticator.challenge_reply();
@@ -240,7 +240,7 @@ void LoginHandler::build_login_challenge(grunt::server::LoginChallenge& packet) 
 }
 
 void LoginHandler::build_login_challenge_decoy(grunt::server::LoginChallenge& packet) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	auto salt = Botan::AutoSeeded_RNG().random_array<32>();
 
@@ -261,25 +261,25 @@ grunt::Result LoginHandler::process_fetch_user_action(const FetchUserAction& act
 
 			return grunt::Result::success;
 		} else {
-			LOG_DEBUG_ASYNC(logger_, "Account not verified: {}", user_->username());
+			LOG_DEBUG(logger_, "Account not verified: {}", user_->username());
 		}
 	} else {
-		LOG_DEBUG_ASYNC(logger_, "Account not found: {}", action.username());
+		LOG_DEBUG(logger_, "Account not found: {}", action.username());
 	}
 
 	return grunt::Result::fail_unknown_account;
 } catch(const dal::exception& e) {
 	metrics_.increment("login_internal_failure");
-	LOG_ERROR_ASYNC(logger_, "DAL failure for {}: {}", action.username(), e.what());
+	LOG_ERROR(logger_, "DAL failure for {}: {}", action.username(), e.what());
 	return grunt::Result::fail_db_busy;
 } catch(const Botan::Exception& e) {
 	metrics_.increment("login_internal_failure");
-	LOG_ERROR_ASYNC(logger_, "Encoding failure for {}: {}", action.username(), e.what());
+	LOG_ERROR(logger_, "Encoding failure for {}: {}", action.username(), e.what());
 	return grunt::Result::fail_db_busy;
 }
 
 void LoginHandler::send_login_challenge(const FetchUserAction& action) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	grunt::server::LoginChallenge response;
 	response.result = process_fetch_user_action(action);
@@ -297,9 +297,9 @@ void LoginHandler::send_login_challenge(const FetchUserAction& action) {
 }
 
 void LoginHandler::send_reconnect_proof(grunt::Result result) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
-	LOG_DEBUG_ASYNC(logger_, "Reconnect result for {}: {}", user_->username(), grunt::to_string(result));
+	LOG_DEBUG(logger_, "Reconnect result for {}: {}", user_->username(), grunt::to_string(result));
 
 	if(result == grunt::Result::success) {
 		metrics_.increment("login_success");
@@ -313,7 +313,7 @@ void LoginHandler::send_reconnect_proof(grunt::Result result) {
 }
 
 void LoginHandler::send_reconnect_challenge(const FetchSessionKeyAction& action) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	grunt::server::ReconnectChallenge response;
 	response.result = grunt::Result::success;
@@ -329,11 +329,11 @@ void LoginHandler::send_reconnect_challenge(const FetchSessionKeyAction& action)
 	} else if(status == rpc::Account::Status::session_not_found) {
 		metrics_.increment("login_failure");
 		response.result = grunt::Result::fail_noaccess;
-		LOG_DEBUG_ASYNC(logger_, "Reconnect failed, session not found for {}", user_->username());
+		LOG_DEBUG(logger_, "Reconnect failed, session not found for {}", user_->username());
 	} else {
 		metrics_.increment("login_internal_failure");
 		response.result = grunt::Result::fail_db_busy;
-		LOG_ERROR_ASYNC(logger_, "{} from peer during reconnect challenge",
+		LOG_ERROR(logger_, "{} from peer during reconnect challenge",
 		                utility::fb_status(status, rpc::Account::EnumNamesStatus()));
 	}
 
@@ -341,7 +341,7 @@ void LoginHandler::send_reconnect_challenge(const FetchSessionKeyAction& action)
 }
 
 bool LoginHandler::validate_pin(const grunt::client::LoginProof& packet) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	// no PIN was expected, nothing to validate
 	if(user_->pin_method() == PINMethod::none) {
@@ -368,10 +368,10 @@ bool LoginHandler::validate_pin(const grunt::client::LoginProof& packet) const {
 	} else if(user_->pin_method() == PINMethod::static_fixed) {
 		result = pin_auth.validate_pin(pin_salt_, packet.pin_salt, packet.pin_hash, user_->pin());
 	} else {
-		LOG_ERROR_ASYNC(logger_, "Unknown TOTP method, {}", std::to_underlying(user_->pin_method()));
+		LOG_ERROR(logger_, "Unknown TOTP method, {}", std::to_underlying(user_->pin_method()));
 	}
 
-	LOG_DEBUG_ASYNC(logger_, "PIN authentication for {} {}", user_->username(), result? "OK" : "failed");
+	LOG_DEBUG(logger_, "PIN authentication for {} {}", user_->username(), result? "OK" : "failed");
 	return result;
 }
 
@@ -393,7 +393,7 @@ bool LoginHandler::validate_client_integrity(std::span<const std::uint8_t> hash,
 bool LoginHandler::validate_client_integrity(std::span<const std::uint8_t> client_hash,
                                              std::span<const uint8_t> salt,
                                              const bool reconnect) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	// client doesn't bother to checksum the binaries on reconnect, it just hashes the salt (=])
 	std::array<std::uint8_t, hash_sizes::sha160> checksum{}; // all-zero hash
@@ -414,7 +414,7 @@ bool LoginHandler::validate_client_integrity(std::span<const std::uint8_t> clien
 }
 
 void LoginHandler::handle_login_proof(const grunt::Packet& packet) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	auto& proofs = dynamic_cast<const grunt::client::LoginProof&>(packet);
 
@@ -463,7 +463,7 @@ void LoginHandler::handle_login_proof(const grunt::Packet& packet) {
 }
 
 void LoginHandler::handle_login_spoof(const grunt::Packet& packet) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	auto& proof_packet = dynamic_cast<const grunt::client::LoginProof&>(packet);
 
@@ -476,7 +476,7 @@ void LoginHandler::handle_login_spoof(const grunt::Packet& packet) {
 }
 
 void LoginHandler::send_login_proof(grunt::Result result, bool survey) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	grunt::server::LoginProof response;
 	response.result = result;
@@ -490,21 +490,21 @@ void LoginHandler::send_login_proof(grunt::Result result, bool survey) {
 	}
 
 	if(user_) {
-		LOG_DEBUG_ASYNC(logger_, "Login result for {}: {}", user_->username(), grunt::to_string(result));
+		LOG_DEBUG(logger_, "Login result for {}: {}", user_->username(), grunt::to_string(result));
 	}
 
 	send(response);
 }
 
 void LoginHandler::on_character_data(const FetchCharacterCounts& action) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	try {
 		state_data_ = action.get_result();
 	} catch(const dal::exception& e) { // not a fatal exception, we'll keep going without the data
 		state_data_ = CharacterCount();
 		metrics_.increment("login_internal_failure");
-		LOG_ERROR_ASYNC(logger_, "DAL failure for {}: {}", user_->username(), e.what());
+		LOG_ERROR(logger_, "DAL failure for {}: {}", user_->username(), e.what());
 	}
 
 	update_state(LoginState::request_realms);
@@ -522,7 +522,7 @@ void LoginHandler::on_character_data(const FetchCharacterCounts& action) {
 	send_login_proof(grunt::Result::success, state_ == LoginState::survey_initiate);
 
 	if(state_ == LoginState::survey_initiate) {
-		LOG_DEBUG_ASYNC(logger_, "Initiating survey transfer...");
+		LOG_DEBUG(logger_, "Initiating survey transfer...");
 		auto meta = survey_.meta(challenge_.platform, challenge_.os);
 		assert(meta);
 		initiate_file_transfer(*meta);
@@ -530,7 +530,7 @@ void LoginHandler::on_character_data(const FetchCharacterCounts& action) {
 }
 
 void LoginHandler::on_session_write(const RegisterSessionAction& action) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	auto result = action.get_result();
 	grunt::Result response = grunt::Result::success;
@@ -542,7 +542,7 @@ void LoginHandler::on_session_write(const RegisterSessionAction& action) {
 	} else {
 		metrics_.increment("login_internal_failure");
 		response = grunt::Result::fail_db_busy;
-		LOG_ERROR_ASYNC(logger_, "{} from peer during login",
+		LOG_ERROR(logger_, "{} from peer during login",
 		                utility::fb_status(result, rpc::Account::EnumNamesStatus()));
 	}
 
@@ -555,7 +555,7 @@ void LoginHandler::on_session_write(const RegisterSessionAction& action) {
 }
 
 void LoginHandler::handle_reconnect_proof(const grunt::Packet& packet) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	auto& reconn_proof = dynamic_cast<const grunt::client::ReconnectProof&>(packet);
 
@@ -575,7 +575,7 @@ void LoginHandler::handle_reconnect_proof(const grunt::Packet& packet) {
 }
 
 void LoginHandler::send_realm_list(const grunt::Packet& packet) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	// todo - move these checks (inc. dynamic_casts) out of the handler functions
 	if(packet.opcode != grunt::Opcode::cmd_realm_list) {
@@ -609,7 +609,7 @@ void LoginHandler::send_realm_list(const grunt::Packet& packet) {
 }
 
 void LoginHandler::patch_client(const grunt::client::LoginChallenge& challenge) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	auto meta = patcher_.find_patch(challenge.version, challenge.locale,
 	                                challenge.platform, challenge.os);
@@ -625,11 +625,11 @@ void LoginHandler::patch_client(const grunt::client::LoginChallenge& challenge) 
 
 	auto& fmeta = meta->file_meta;
 
-	LOG_DEBUG_ASYNC(logger_, "Initiating patch transfer, {}", fmeta.name);
+	LOG_DEBUG(logger_, "Initiating patch transfer, {}", fmeta.name);
 	std::ifstream patch(fmeta.path + fmeta.name, std::ifstream::binary);
 
 	if(!patch) {
-		LOG_ERROR_ASYNC(logger_, "Could not open patch, {}", fmeta.name);
+		LOG_ERROR(logger_, "Could not open patch, {}", fmeta.name);
 		return;
 	}
 
@@ -645,7 +645,7 @@ void LoginHandler::patch_client(const grunt::client::LoginChallenge& challenge) 
 }
 
 void LoginHandler::initiate_file_transfer(const FileMeta& meta) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 	
 	transfer_state_.size = meta.size;
 
@@ -657,7 +657,7 @@ void LoginHandler::initiate_file_transfer(const FileMeta& meta) {
 }
 
 void LoginHandler::handle_survey_result(const grunt::Packet& packet) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	auto& survey = dynamic_cast<const grunt::client::SurveyResult&>(packet);
 
@@ -665,7 +665,7 @@ void LoginHandler::handle_survey_result(const grunt::Packet& packet) {
 	update_state(LoginState::request_realms);
 
 	if(survey.survey_id != survey_.id()) {
-		LOG_DEBUG_ASYNC(logger_, "Received an invalid survey ID from {}", user_->username());
+		LOG_DEBUG(logger_, "Received an invalid survey ID from {}", user_->username());
 		return;
 	}
 
@@ -688,22 +688,22 @@ void LoginHandler::handle_survey_result(const grunt::Packet& packet) {
 }
 
 void LoginHandler::on_survey_write(const SaveSurveyAction& action) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	if(action.error()) {
-		LOG_ERROR_ASYNC(logger_, "DAL failure for {}, {}", user_->username(), action.exception().what());
+		LOG_ERROR(logger_, "DAL failure for {}, {}", user_->username(), action.exception().what());
 	}
 }
 
 void LoginHandler::set_transfer_offset(const grunt::Packet& packet) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	auto& resume = dynamic_cast<const grunt::client::TransferResume&>(packet);
 	transfer_state_.offset = resume.offset;
 }
 
 void LoginHandler::handle_transfer_ack(const grunt::Packet& packet, bool survey) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	switch(packet.opcode) {
 		case grunt::Opcode::cmd_xfer_resume:
@@ -723,12 +723,12 @@ void LoginHandler::handle_transfer_ack(const grunt::Packet& packet, bool survey)
 }
 
 void LoginHandler::handle_transfer_abort() {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 	transfer_state_.abort = true;
 }
 
 void LoginHandler::transfer_chunk() {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	auto remaining = transfer_state_.size - transfer_state_.offset;
 	std::uint16_t read_size = grunt::server::TransferData::MAX_CHUNK_SIZE;
@@ -748,7 +748,7 @@ void LoginHandler::transfer_chunk() {
 		transfer_state_.file.read(reinterpret_cast<char*>(response.chunk.data()), read_size);
 
 		if(!transfer_state_.file) {
-			LOG_ERROR_ASYNC(logger_, "Patch reading failed during transfer");
+			LOG_ERROR(logger_, "Patch reading failed during transfer");
 			return;
 		}
 	}
@@ -761,7 +761,7 @@ void LoginHandler::transfer_chunk() {
 }
 
 void LoginHandler::on_chunk_complete() {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	if(transfer_state_.abort) {
 		return;

--- a/src/login/LoginSession.cpp
+++ b/src/login/LoginSession.cpp
@@ -43,24 +43,24 @@ LoginSession::LoginSession(SessionManager& sessions,
 }
 
 bool LoginSession::handle_packet(spark::io::pmr::Buffer& buffer) try {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	auto result = grunt_handler_.process_buffer(buffer);
 
 	if(result) {
 		const auto& packet = *result;
-		LOG_TRACE_ASYNC(logger_, "{} -> {}", remote_address(), grunt::to_string(packet.opcode));
+		LOG_TRACE(logger_, "{} -> {}", remote_address(), grunt::to_string(packet.opcode));
 		return handler_.update_state(packet);
 	}
 
 	return true;
 } catch(const grunt::bad_packet& e) {
-	LOG_DEBUG(logger_) << e.what() << LOG_ASYNC;
+	LOG_DEBUG(logger_, e.what());
 	return false;
 }
 
 void LoginSession::execute_async(std::unique_ptr<Action> action) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	auto self(shared_from_this());
 	std::shared_ptr<Action> shared_act(std::move(action));
@@ -77,19 +77,19 @@ void LoginSession::execute_async(std::unique_ptr<Action> action) {
 }
 
 void LoginSession::async_completion(Action& action) try {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	if(!handler_.update_state(action)) {
 		close_session(); // todo change
 	}
 } catch(const std::exception& e) {
-	LOG_DEBUG(logger_) << e.what() << LOG_ASYNC;
+	LOG_DEBUG(logger_, e.what());
 	close_session();
 }
 
 void LoginSession::write_packet(const grunt::Packet& packet, WriteCallback&& cb) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
-	LOG_TRACE_ASYNC(logger_, "{} <- {}", remote_address(), grunt::to_string(packet.opcode));
+	LOG_TRACE(logger_, log_func);
+	LOG_TRACE(logger_, "{} <- {}", remote_address(), grunt::to_string(packet.opcode));
 	write(packet, std::move(cb));
 }
 

--- a/src/login/MonitorCallbacks.cpp
+++ b/src/login/MonitorCallbacks.cpp
@@ -41,19 +41,19 @@ void monitor_log_callback(const Monitor::Source& source, Monitor::Severity sever
 
 	switch(severity) {
 		case Monitor::Severity::fatal:
-			LOG_FATAL(logger) << message << LOG_ASYNC;
+			LOG_FATAL(logger, message);
 			break;
 		case Monitor::Severity::error:
-			LOG_ERROR(logger) << message << LOG_ASYNC;
+			LOG_ERROR(logger, message);
 			break;
 		case Monitor::Severity::warn:
-			LOG_WARN(logger) << message << LOG_ASYNC;
+			LOG_WARN(logger, message);
 			break;
 		case Monitor::Severity::info:
-			LOG_INFO(logger) << message << LOG_ASYNC;
+			LOG_INFO(logger, message);
 			break;
 		case Monitor::Severity::debug:
-			LOG_DEBUG(logger) << message << LOG_ASYNC;
+			LOG_DEBUG(logger, message);
 			break;
 	}
 }

--- a/src/login/NetworkListener.h
+++ b/src/login/NetworkListener.h
@@ -43,7 +43,7 @@ class NetworkListener final {
 	std::atomic_bool stopped_;
 
 	void accept_connection() {
-		LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+		LOG_TRACE(logger_, log_func);
 
 		if(!acceptor_.is_open()) {
 			return;
@@ -58,7 +58,7 @@ class NetworkListener final {
 				const auto& ep = socket_.remote_endpoint(ec);
 
 				if(ec) {
-					LOG_DEBUG_ASYNC(logger_, "Aborted connection, remote peer disconnected");
+					LOG_DEBUG(logger_, "Aborted connection, remote peer disconnected");
 					metrics_.increment("aborted_connections");
 					return;
 				}
@@ -66,12 +66,12 @@ class NetworkListener final {
 				const auto& ip = ep.address();
 
 				if(!ban_list_.is_banned(ip)) {
-					LOG_DEBUG_ASYNC(logger_, "Accepted connection from {}", ip.to_string());
+					LOG_DEBUG(logger_, "Accepted connection from {}", ip.to_string());
 					metrics_.increment("accepted_connections");
 					start_session(std::move(socket_));
 					peak_connections_ = std::max(peak_connections_, sessions_.count());
 				} else {
-					LOG_DEBUG_ASYNC(logger_, "Rejected connection {} from banned IP range", ip.to_string());
+					LOG_DEBUG(logger_, "Rejected connection {} from banned IP range", ip.to_string());
 					metrics_.increment("rejected_connections");
 				}
 			}
@@ -82,7 +82,7 @@ class NetworkListener final {
 	}
 
 	void start_session(tcp_strand_socket socket) {
-		LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+		LOG_TRACE(logger_, log_func);
 		auto session = session_builder_.create(sessions_, std::move(socket), logger_);
 		sessions_.start(session);
 	}
@@ -116,7 +116,7 @@ public:
 			return;
 		}
 
-		LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+		LOG_TRACE(logger_, log_func);
 		acceptor_.close();
 		sessions_.stop_all();
 		stopped_ = true;

--- a/src/login/NetworkSession.h
+++ b/src/login/NetworkSession.h
@@ -165,7 +165,7 @@ private:
 			return;
 		}
 
-		LOG_DEBUG_ASYNC(logger_, "Idle timeout triggered on {}", remote_address());
+		LOG_DEBUG(logger_, "Idle timeout triggered on {}", remote_address());
 		close_session();
 	}
 
@@ -224,7 +224,7 @@ public:
 		auto self(this->shared_from_this());
 
 		boost::asio::post(socket_.get_executor(), [this, self] {
-			LOG_DEBUG_ASYNC(logger_, "Closing connection to {}", remote_address());
+			LOG_DEBUG(logger_, "Closing connection to {}", remote_address());
 
 			stop_timer();
 			boost::system::error_code ec; // we don't care about any errors

--- a/src/login/RealmClient.cpp
+++ b/src/login/RealmClient.cpp
@@ -22,17 +22,17 @@ RealmClient::RealmClient(spark::Server& server, RealmList& realmlist, log::Logge
 }
 
 void RealmClient::on_link_up(const spark::Link& link) {
-	LOG_DEBUG_ASYNC(logger_, "Link up: {}", link.peer_banner);
+	LOG_DEBUG(logger_, "Link up: {}", link.peer_banner);
 	request_realm_status(link);
 }
 
 void RealmClient::on_link_down(const spark::Link& link) {
-	LOG_DEBUG_ASYNC(logger_, "Link closed: {}", link.peer_banner);
+	LOG_DEBUG(logger_, "Link closed: {}", link.peer_banner);
 	mark_realm_offline(link);
 }
 
 void RealmClient::connect_failed(const std::string_view ip, const std::uint16_t port) {
-	LOG_DEBUG_ASYNC(logger_, "Failed to connect to realm on {}:{}", ip, port);
+	LOG_DEBUG(logger_, "Failed to connect to realm on {}:{}", ip, port);
 }
 
 void RealmClient::request_realm_status(const spark::Link& link) {
@@ -54,7 +54,7 @@ void RealmClient::mark_realm_offline(const spark::Link& link) {
 	std::optional<Realm> realm = realmlist_.get_realm(realm_id);
 	assert(realm);
 	realm->flags |= Realm::Flags::offline;
-	LOG_INFO_ASYNC(logger_, "Setting realm {} to offline", realm->name);
+	LOG_INFO(logger_, "Setting realm {} to offline", realm->name);
 	realmlist_.add_realm(std::move(*realm));
 }
 
@@ -77,22 +77,22 @@ void RealmClient::update_realm(const Status& msg) {
 		.region = static_cast<dbc::Cfg_Categories::Region>(msg.region())
 	};
 
-	LOG_INFO_ASYNC(logger_, "Updating status for realm {} ({}, {})", realm.id, realm.name, realm.address);
+	LOG_INFO(logger_, "Updating status for realm {} ({}, {})", realm.id, realm.name, realm.address);
 	realmlist_.add_realm(std::move(realm));
 }
 
 void RealmClient::handle_get_status_response(const spark::Link& link, const Status& msg) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	if(!validate_status(msg)) {
-		LOG_WARN_ASYNC(logger_, "Incompatible realm update from {}", link.peer_banner);
+		LOG_WARN(logger_, "Incompatible realm update from {}", link.peer_banner);
 		return;
 	}
 
 	// realm may have gone down unexpectedly and restarted before the prior link has terminated
 	if(auto it = realms_.find(msg.id()); it != realms_.end()) {
 		if(link.peer_banner != it->second) {
-			LOG_WARN_ASYNC(logger_, "Realm associated with {} will now be associated with {}",
+			LOG_WARN(logger_, "Realm associated with {} will now be associated with {}",
 			               it->second, link.peer_banner);
 		}
 	}

--- a/src/login/Service.cpp
+++ b/src/login/Service.cpp
@@ -81,7 +81,7 @@ int Service::run(const opts::variables_map& args) try {
 
 	// Spawn worker threads for Asio
 	const auto concurrency = thread::hardware_concurrency([&](auto msg) {
-		LOG_ERROR_SYNC(logger, msg);
+		SLOG_ERROR(logger, msg);
 	});
 
 	std::vector<std::jthread> threads;
@@ -96,7 +96,7 @@ int Service::run(const opts::variables_map& args) try {
 
 	return EXIT_SUCCESS;
 } catch(const std::exception& e) {
-	LOG_FATAL_SYNC(logger, e.what());
+	SLOG_FATAL(logger, e.what());
 	return EXIT_FAILURE;
 }
 
@@ -113,7 +113,7 @@ void Service::initialise(const opts::variables_map& args) {
 		builds += to_string(client) + " ";
 	}
 
-	LOG_INFO_SYNC(logger, "Allowed client builds: {}", builds);
+	SLOG_INFO(logger, "Allowed client builds: {}", builds);
 
 	auto stun = create_stun_client(args);
 	const auto stun_enabled = args["stun.enabled"].as<bool>();
@@ -126,15 +126,15 @@ void Service::initialise(const opts::variables_map& args) {
 			stun_log_callback(severity, reason, logger);
 		});
 
-		LOG_INFO_SYNC(logger, "Starting STUN query...");
+		SLOG_INFO(logger, "Starting STUN query...");
 		stun_res = stun.external_address();
 	}
 
-	LOG_INFO_SYNC(logger, "Seeding xorshift RNG...");
+	SLOG_INFO(logger, "Seeding xorshift RNG...");
 	seed_xorshift_rng();
 
 	const auto concurrency = thread::hardware_concurrency([&](auto msg) {
-		LOG_ERROR_SYNC(logger, msg);
+		SLOG_ERROR(logger, msg);
 	});
 
 	auto max_conns = args["database.max_connections"].as<unsigned short>();
@@ -143,14 +143,14 @@ void Service::initialise(const opts::variables_map& args) {
 		max_conns = concurrency;
 	}
 	
-	LOG_INFO_SYNC(logger, "Max. database connections set to {} ({} cores)", max_conns, concurrency);
+	SLOG_INFO(logger, "Max. database connections set to {} ({} cores)", max_conns, concurrency);
 
-	LOG_INFO_SYNC(logger, "Initialising database connection pool...");
+	SLOG_INFO(logger, "Initialising database connection pool...");
 	ctx->conn_pool = std::make_unique<connection_pool::Pool<drivers::AutoSelect>>(
 		init_database(args, logger)
 	);
 
-	LOG_INFO_SYNC(logger, "Initialising DAOs...");
+	SLOG_INFO(logger, "Initialising DAOs...");
 	auto user_dao = dal::user_dao(ctx->conn_pool->get());
 	auto patch_dao = dal::patch_dao(ctx->conn_pool->get());
 	auto realm_dao = dal::realm_dao(ctx->conn_pool->get());
@@ -159,7 +159,7 @@ void Service::initialise(const opts::variables_map& args) {
 	ctx->ip_ban_cache = std::make_unique<IPBanCache>(ip_ban_dao.all_bans());
 
 	// Load integrity, patch and survey data
-	LOG_INFO_SYNC(logger, "Loading client integrity validation data...");
+	SLOG_INFO(logger, "Loading client integrity validation data...");
 	ctx->integrity_data = std::make_unique<IntegrityData>();
 
 	if(args["integrity.enabled"].as<bool>()) {
@@ -167,7 +167,7 @@ void Service::initialise(const opts::variables_map& args) {
 		ctx->integrity_data->add_versions(allowed_builds, bin_path);
 	}
 
-	LOG_INFO_SYNC(logger, "Loading patch data...");
+	SLOG_INFO(logger, "Loading patch data...");
 	auto patches = Patcher::load_patches(
 		args["patches.bin_path"].as<std::string>(), patch_dao
 	);
@@ -176,7 +176,7 @@ void Service::initialise(const opts::variables_map& args) {
 	ctx->survey = std::make_unique<Survey>(args["survey.id"].as<std::uint32_t>());
 
 	if(ctx->survey->id()) {
-		LOG_INFO_SYNC(logger, "Loading survey data...");
+		SLOG_INFO(logger, "Loading survey data...");
 
 		ctx->survey->add_data(
 			grunt::Platform::x86, grunt::System::Win,
@@ -184,14 +184,14 @@ void Service::initialise(const opts::variables_map& args) {
 		);
 	}
 
-	LOG_INFO_SYNC(logger, "Loading realm list...");
+	SLOG_INFO(logger, "Loading realm list...");
 	ctx->realm_list = std::make_unique<RealmList>(realm_dao.get_realms());
 
 	const auto realm_count = ctx->realm_list->realms()->size();
-	LOG_INFO_SYNC(logger, "Added {} realm{}", realm_count, (!realm_count || realm_count > 1? "s" : ""));
+	SLOG_INFO(logger, "Added {} realm{}", realm_count, (!realm_count || realm_count > 1? "s" : ""));
 
 	for(const auto& realm : *ctx->realm_list->realms() | std::views::values) {
-		LOG_DEBUG_SYNC(logger, "#{} {}", realm.id, realm.name);
+		SLOG_DEBUG(logger, "#{} {}", realm.id, realm.name);
 	}
 
 	validate_realms(*ctx->realm_list, logger, args);
@@ -199,7 +199,7 @@ void Service::initialise(const opts::variables_map& args) {
 	const auto& s_address = args["spark.address"].as<std::string>();
 	auto s_port = args["spark.port"].as<std::uint16_t>();
 
-	LOG_INFO_SYNC(logger, "Starting RPC services...");
+	SLOG_INFO(logger, "Starting RPC services...");
 	ctx->rpc = std::make_unique<spark::Server>(ioc, app_name, s_address, s_port, logger);
 	ctx->rpc_account = std::make_unique<AccountClient>(*ctx->rpc, logger);
 	ctx->rpc_realm = std::make_unique<RealmClient>(*ctx->rpc, *ctx->realm_list, logger);
@@ -207,7 +207,7 @@ void Service::initialise(const opts::variables_map& args) {
 	// Start metrics service
 	ctx->metrics = start_metrics(ioc, args);
 
-	LOG_INFO_SYNC(logger, "Starting thread pool with {} threads...", concurrency);
+	SLOG_INFO(logger, "Starting thread pool with {} threads...", concurrency);
 	ctx->thread_pool = std::make_unique<thread::ThreadPool>(concurrency);
 
 	const LoginHandler::Options config {
@@ -229,7 +229,7 @@ void Service::initialise(const opts::variables_map& args) {
 	const auto port = args["network.port"].as<std::uint16_t>();
 	const auto tcp_no_delay = args["network.tcp_no_delay"].as<bool>();
 
-	LOG_INFO_SYNC(logger, "Starting network service on {}:{}...", interface, port);
+	SLOG_INFO(logger, "Starting network service on {}:{}...", interface, port);
 	ctx->server = std::make_unique<NetworkListener>(
 		ioc, interface, port, tcp_no_delay, *ctx->login_session_builder,
 		*ctx->ip_ban_cache, logger, *ctx->metrics
@@ -237,7 +237,7 @@ void Service::initialise(const opts::variables_map& args) {
 
 	// Start monitoring service
 	if(args["monitor.enabled"].as<bool>()) {
-		LOG_INFO_SYNC(logger, "Starting monitoring service...");
+		SLOG_INFO(logger, "Starting monitoring service...");
 
 		ctx->monitor = std::make_unique<Monitor>(	
 			ioc, args["monitor.interface"].as<std::string>(),
@@ -260,11 +260,11 @@ void Service::initialise(const opts::variables_map& args) {
 	}, 5s);
 
 	// Misc. information
-	LOG_INFO_SYNC(logger, "Max allowed sockets: {}", utility::max_sockets_desc());
+	SLOG_INFO(logger, "Max allowed sockets: {}", utility::max_sockets_desc());
 	
 	// Retrieve STUN result
 	if(stun_enabled) {
-		LOG_INFO_SYNC(logger, "Waiting on STUN result...");
+		SLOG_INFO(logger, "Waiting on STUN result...");
 
 		const auto result = stun_res.get();
 		log_stun_result(stun, result, port, logger);
@@ -283,12 +283,12 @@ void Service::initialise(const opts::variables_map& args) {
 	}
 
 	// Install service command handlers
-	LOG_INFO_SYNC(logger, "Registering command handlers...");
+	SLOG_INFO(logger, "Registering command handlers...");
 	register_commands();
 
 	// All done setting up
 	boost::asio::dispatch(ioc, [this, time]() {
-		LOG_INFO_SYNC(logger, "{} started successfully in {}", app_name,
+		SLOG_INFO(logger, "{} started successfully in {}", app_name,
 			utility::time_elapsed_format(time));
 
 		start_time = std::chrono::steady_clock::now();
@@ -299,13 +299,13 @@ void Service::register_commands() {
 	auto ctx = context.get();
 
 	ctx->cmd_exec = std::make_unique<utility::CommandExecutor>(ioc, [&](const auto& reason) {
-		LOG_CONSOLE_ERROR_ASYNC(logger, "Command could not be executed, {}", reason);
+		LOG_CONERR(logger, "Command could not be executed, {}", reason);
 	});
 	
 	auto handle = registry.scoped_insert(commands::Command::create("connections")
 		->description("Display open connection count")
 		->handler(ctx->cmd_exec->wrap([this, &server = *ctx->server](auto& command) {
-			LOG_CONSOLE_ASYNC(logger, "{} active connection(s), {} peak",
+			LOG_CONSOLE(logger, "{} active connection(s), {} peak",
 				server.connection_count(), server.peak_connections());
 		}))
 	);
@@ -316,7 +316,7 @@ void Service::register_commands() {
 		->description("Display service uptime")
 		->handler(ctx->cmd_exec->wrap([&](auto& command) {
 			const auto uptime = std::chrono::steady_clock::now() - start_time;
-			LOG_CONSOLE_ASYNC(logger, "Server has been up for {}", utility::time_duration_format(uptime));
+			LOG_CONSOLE(logger, "Server has been up for {}", utility::time_duration_format(uptime));
 		}))
 	);
 
@@ -327,7 +327,7 @@ std::unique_ptr<Metrics> Service::start_metrics(boost::asio::io_context& service
 	auto metrics = std::make_unique<Metrics>();
 
 	if(args["metrics.enabled"].as<bool>()) {
-		LOG_INFO_SYNC(logger, "Starting metrics service...");
+		SLOG_INFO(logger, "Starting metrics service...");
 		metrics = std::make_unique<MetricsImpl>(
 			service, args["metrics.statsd_host"].as<std::string>(),
 			args["metrics.statsd_port"].as<std::uint16_t>()
@@ -344,17 +344,17 @@ void Service::seed_xorshift_rng() {
 }
 
 void validate_realms(const RealmList& realmlist, log::Logger& logger, const opts::variables_map& args) {
-	LOG_INFO_SYNC(logger, "Loading DBC data...");
+	SLOG_INFO(logger, "Loading DBC data...");
 
 	dbc::DiskLoader loader(args["dbc.path"].as<std::string>(), [&](auto message) {
-		LOG_DEBUG(logger) << message << LOG_SYNC;
+		SLOG_DEBUG(logger, message);
 	});
 
 	const auto dbcs = loader.load(dbcs_required);
 
 	for(const auto& realm : *realmlist.realms() | std::views::values) {
 		if(!validate_realm(realm, dbcs.cfg_categories)) {
-			LOG_WARN_SYNC(logger, "Validation failed for {} - client may not display this realm", realm.name);
+			SLOG_WARN(logger, "Validation failed for {} - client may not display this realm", realm.name);
 		}
 	}
 }
@@ -366,7 +366,7 @@ void Service::stop() {
 		return;
 	}
 
-	LOG_TRACE_SYNC(logger, "Service termination requested");
+	SLOG_TRACE(logger, "Service termination requested");
 
 	boost::asio::post(ioc, [&] {
 		auto ctx = context.get();
@@ -430,7 +430,7 @@ bool validate_realm(const Realm& realm, const dbc::Store<dbc::Cfg_Categories>& d
 }
 
 void print_lib_versions(log::Logger& logger) {
-	LOG_DEBUG(logger)
+	LOG_DEBUG_STREAM(logger)
 		<< "Compiled with library versions: " << "\n"
 	    << " - Boost " << BOOST_VERSION / 100000 << "."
 	    << BOOST_VERSION / 100 % 1000 << "."

--- a/src/login/grunt/Handler.cpp
+++ b/src/login/grunt/Handler.cpp
@@ -39,10 +39,11 @@ void Handler::dump_bad_packet(const spark::io::buffer_underrun& e,
 
 	auto output = utility::format_packet(contig_buff.data(), contig_buff.size());
 
-	LOG_ERROR(logger_) << "Buffer stream underrun! \nRead request: "
-	                   << e.read_size << " bytes \nBuffer size: " << e.buff_size
-	                   << " bytes \nError triggered by first "
-	                   << valid_bytes << " bytes \n" << output << LOG_ASYNC;
+	LOG_ERROR_STREAM(logger_)
+		<< "Buffer stream underrun! \nRead request: "
+	    << e.read_size << " bytes \nBuffer size: " << e.buff_size
+	    << " bytes \nError triggered by first "
+	    << valid_bytes << " bytes \n" << output << LOG_ASYNC;
 }
 
 void Handler::handle_new_packet(spark::io::pmr::Buffer& buffer) {

--- a/src/login/main.cpp
+++ b/src/login/main.cpp
@@ -54,16 +54,16 @@ int main(int argc, const char* argv[]) try {
 	log::Logger logger;
 	utility::configure_logger(logger, args);
 	log::global_logger(logger);
-	LOG_INFO_SYNC(logger, "Logger configured successfully");
+	SLOG_INFO(logger, "Logger configured successfully");
 
-	LOG_DEBUG_SYNC(logger, "Registering command handlers...");
+	SLOG_DEBUG(logger, "Registering command handlers...");
 	const auto suggestions = args["console_log.suggestions"].as<bool>();
 	commands::Registry registry;
 	utility::register_command_handlers(registry, logger, suggestions);
 	utility::register_shared_commands(registry, logger);
 
 	const auto ret = run(args, logger, registry);
-	LOG_INFO_SYNC(logger, "{} terminated (returned '{}')", login::app_name, ret);
+	SLOG_INFO(logger, "{} terminated (returned '{}')", login::app_name, ret);
 	return ret;
 } catch(const std::exception& e) {
 	std::cerr << e.what();
@@ -80,7 +80,7 @@ int run(const opts::variables_map& args, log::Logger& logger, commands::Registry
 			return;
 		}
 
-		LOG_DEBUG_SYNC(logger, "Received signal {}({})", utility::sig_str(signal), signal);
+		SLOG_DEBUG(logger, "Received signal {}({})", utility::sig_str(signal), signal);
 		signals.clear();
 		service.stop();
 	});
@@ -96,34 +96,34 @@ int run(const opts::variables_map& args, log::Logger& logger, commands::Registry
 	signals.cancel();
 	return ret;
 } catch(const std::exception& e) {
-	LOG_FATAL_SYNC(logger, e.what());
+	SLOG_FATAL(logger, e.what());
 	return EXIT_FAILURE;
 }
 
 void register_shutdown(commands::Registry& registry, boost::asio::io_context& ioc, log::Logger& logger) {
 	shutdown::Handlers handlers {
 		.on_initiate = [&](auto time) {
-			LOG_CONSOLE_ASYNC(logger, "Server will shut down in {}", utility::time_duration_format(time));
+			LOG_CONSOLE(logger, "Server will shut down in {}", utility::time_duration_format(time));
 		},
 			
 		.on_cancel = [&](auto state) {
 			if(state == shutdown::State::pending) {
-				LOG_CONSOLE_ASYNC(logger, "Server shutdown has been cancelled");
+				LOG_CONSOLE(logger, "Server shutdown has been cancelled");
 			} else {
-				LOG_CONSOLE_ASYNC(logger, "No shutdown is pending");
+				LOG_CONSOLE(logger, "No shutdown is pending");
 			}
 		},
 			
 		.on_expire = [&] {
-			LOG_CONSOLE_ASYNC(logger, "Server is shutting down now");
+			LOG_CONSOLE(logger, "Server is shutting down now");
 			std::raise(SIGINT);
 		}, 
 			
 		.on_remaining = [&](auto state, auto time) {
 			if(state == shutdown::State::pending) {
-				LOG_CONSOLE_ASYNC(logger, "Server will shut down in {}", utility::time_duration_format(time));
+				LOG_CONSOLE(logger, "Server will shut down in {}", utility::time_duration_format(time));
 			} else {
-				LOG_CONSOLE_ASYNC(logger, "No shutdown is pending");
+				LOG_CONSOLE(logger, "No shutdown is pending");
 			}
 		}
 	};

--- a/src/mdns/MulticastSocket.cpp
+++ b/src/mdns/MulticastSocket.cpp
@@ -42,7 +42,7 @@ MulticastSocket::MulticastSocket(boost::asio::io_context& context,
 }
 
 void MulticastSocket::receive() {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	if(!socket_.is_open()) {
 		return;
@@ -65,10 +65,10 @@ void MulticastSocket::receive() {
 
 void MulticastSocket::handle_datagram(const std::span<const std::uint8_t> datagram,
                                       const boost::asio::ip::udp::endpoint& ep) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
     if(!handler_) {
-		LOG_ERROR(logger_) << "No packet handler installed?" << LOG_ASYNC; // todo, rework
+		LOG_ERROR(logger_, "No packet handler installed?"); // todo, rework
 		return;
     }
 
@@ -86,7 +86,7 @@ void MulticastSocket::handle_datagram(const std::span<const std::uint8_t> datagr
 	}
 
 	if(datagram.size() > max_size) {
-		LOG_WARN_ASYNC(
+		LOG_WARN(
 			logger_, "Datagram exceeded maximum permitted size of {} bytes. Skipping.", max_size
 		);
 
@@ -97,7 +97,7 @@ void MulticastSocket::handle_datagram(const std::span<const std::uint8_t> datagr
 }
 
 void MulticastSocket::send(std::unique_ptr<std::vector<std::uint8_t>> buffer) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	if(!socket_.is_open()) {
 		return;
@@ -106,22 +106,22 @@ void MulticastSocket::send(std::unique_ptr<std::vector<std::uint8_t>> buffer) {
 	socket_.async_send_to(boost::asio::buffer(*buffer), ep_,
 		[&, buff = std::move(buffer)](const boost::system::error_code& ec, std::size_t size) {
 			if(ec) {
-				LOG_ERROR_ASYNC(logger_, "Error on sending datagram: {}, size {}", ec.message(), size);
+				LOG_ERROR(logger_, "Error on sending datagram: {}, size {}", ec.message(), size);
 			}
 		}
 	);
 }
 
 void MulticastSocket::register_handler(Handler* handler) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
     handler_ = handler;
 }
 
 void MulticastSocket::deregister_handler(const Handler* handler) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	if(handler != handler_) {
-		LOG_ERROR_ASYNC(logger_, "Attempted to deregister handler that wasn't registered");
+		LOG_ERROR(logger_, "Attempted to deregister handler that wasn't registered");
 	}
 
 	handler_ = nullptr;

--- a/src/mdns/NSDService.cpp
+++ b/src/mdns/NSDService.cpp
@@ -18,11 +18,11 @@ NSDService::NSDService(Server& spark, log::Logger& logger)
 	  logger_(logger) {}
 
 void NSDService::on_link_up(const Link& link) {
-	LOG_INFO_ASYNC(logger_, "Link up to {}", link.peer_banner);
+	LOG_INFO(logger_, "Link up to {}", link.peer_banner);
 }
 
 void NSDService::on_link_down(const Link& link) {
-	LOG_INFO_ASYNC(logger_, "Link down to {}", link.peer_banner);
+	LOG_INFO(logger_, "Link down to {}", link.peer_banner);
 }
 
 } // ember

--- a/src/mdns/Server.cpp
+++ b/src/mdns/Server.cpp
@@ -18,7 +18,7 @@ namespace ember::dns {
 
 Server::Server(std::unique_ptr<Socket> socket, log::Logger& logger)
                : socket_(std::move(socket)), logger_(logger) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
     socket_->register_handler(this);
 }
 
@@ -27,16 +27,16 @@ Server::~Server() {
 }
 
 void Server::handle_datagram(std::span<const std::uint8_t> datagram) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	const auto result = deserialise(datagram);
 
 	if(!result) {
-		LOG_WARN_ASYNC(logger_, "DNS query deserialising failed: {}", to_string(result.error()));
+		LOG_WARN(logger_, "DNS query deserialising failed: {}", to_string(result.error()));
 		return;
 	}
 
-	LOG_TRACE(logger_) << to_string(result.value()) << LOG_ASYNC;
+	LOG_TRACE(logger_, to_string(result.value()));
 
 	if(result->header.flags.qr == 0) {
 		handle_question(result.value());
@@ -46,7 +46,7 @@ void Server::handle_datagram(std::span<const std::uint8_t> datagram) {
 }
 
 void Server::handle_question(const Query& query) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	Query out{};
 	out.questions = query.questions;
@@ -104,7 +104,7 @@ void Server::handle_question(const Query& query) {
 }
 
 void Server::handle_response(const Query& query) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 }
 
 void Server::shutdown() {

--- a/src/mdns/Service.cpp
+++ b/src/mdns/Service.cpp
@@ -36,10 +36,10 @@ int Service::run(const opts::variables_map& args) try {
 	initialise(args);
 	ioc.run();
 
-	LOG_INFO_SYNC(logger, "{} shutting down...", app_name);
+	SLOG_INFO(logger, "{} shutting down...", app_name);
 	return EXIT_SUCCESS;
 } catch(const std::exception& e) {
-	LOG_FATAL_SYNC(logger, e.what());
+	SLOG_FATAL(logger, e.what());
 	return EXIT_FAILURE;
 }
 
@@ -52,23 +52,23 @@ void Service::initialise(const opts::variables_map& args) {
 	const auto port = args["mdns.port"].as<std::uint16_t>();
 
 	// start multicast DNS services
-	LOG_INFO_SYNC(logger, "Starting multicaster...");
+	SLOG_INFO(logger, "Starting multicaster...");
 	auto socket = std::make_unique<dns::MulticastSocket>(ioc, iface, group, port, logger);
 
-	LOG_INFO_SYNC(logger, "Starting DNS server handler...");
+	SLOG_INFO(logger, "Starting DNS server handler...");
 	ctx->server = std::make_unique<Server>(std::move(socket), logger);
 
 	const auto& spark_iface = args["spark.address"].as<std::string>();
 	const auto spark_port = args["spark.port"].as<std::uint16_t>();
 
 	// start RPC services
-	LOG_INFO_SYNC(logger, "Starting RPC services...");
+	SLOG_INFO(logger, "Starting RPC services...");
 	ctx->spark = std::make_unique<spark::Server>(ioc, app_name, spark_iface, spark_port, logger);
 	ctx->nsd_service = std::make_unique<NSDService>(*ctx->spark, logger);
 
 	// All done setting up
 	boost::asio::dispatch(ioc, [&, time]() {
-		LOG_INFO_SYNC(logger, "{} started successfully in {}", app_name,
+		SLOG_INFO(logger, "{} started successfully in {}", app_name,
 			utility::time_elapsed_format(time));
 
 		start_time = std::chrono::steady_clock::now();
@@ -82,7 +82,7 @@ void Service::stop() {
 		return;
 	}
 
-	LOG_TRACE_SYNC(logger, "Service termination requested");
+	SLOG_TRACE(logger, "Service termination requested");
 
 	boost::asio::post(ioc, [&] {
 		auto ctx = context.get();

--- a/src/mdns/main.cpp
+++ b/src/mdns/main.cpp
@@ -47,16 +47,16 @@ int main(int argc, const char* argv[]) try {
 	log::Logger logger;
 	utility::configure_logger(logger, args);
 	log::global_logger(logger);
-	LOG_INFO_SYNC(logger, "Logger configured successfully");
+	SLOG_INFO(logger, "Logger configured successfully");
 
-	LOG_DEBUG_SYNC(logger, "Registering command handlers...");
+	SLOG_DEBUG(logger, "Registering command handlers...");
 	const auto suggestions = args["console_log.suggestions"].as<bool>();
 	commands::Registry registry;
 	utility::register_command_handlers(registry, logger, suggestions);
 	utility::register_shared_commands(registry, logger);
 
 	const auto ret = run(args, logger, registry);
-	LOG_INFO_SYNC(logger, "{} terminated (returned '{}')", dns::app_name, ret);
+	SLOG_INFO(logger, "{} terminated (returned '{}')", dns::app_name, ret);
 	return ret;
 } catch(const std::exception& e) {
 	std::cerr << e.what();
@@ -74,7 +74,7 @@ int run(const opts::variables_map& args, log::Logger& logger, commands::Registry
 			return;
 		}
 
-		LOG_DEBUG_SYNC(logger, "Received signal {}({})", utility::sig_str(signal), signal);
+		SLOG_DEBUG(logger, "Received signal {}({})", utility::sig_str(signal), signal);
 		service.stop();
 	});
 

--- a/src/realm/AccountClient.cpp
+++ b/src/realm/AccountClient.cpp
@@ -21,20 +21,20 @@ AccountClient::AccountClient(spark::Server& spark, log::Logger& logger)
 }
 
 void AccountClient::on_link_up(const spark::Link& link) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 	link_ = link;
 }
 
 void AccountClient::on_link_down(const spark::Link& link) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 }
 
 void AccountClient::connect_failed(const std::string_view ip, const std::uint16_t port) {
-	LOG_INFO_ASYNC(logger_, "Failed to connect to account service on {}:{}", ip, port);
+	LOG_INFO(logger_, "Failed to connect to account service on {}:{}", ip, port);
 }
 
 void AccountClient::locate_session(const std::uint32_t account_id, LocateCB cb) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	SessionLookupT msg {
 		.account_id = account_id
@@ -46,7 +46,7 @@ void AccountClient::locate_session(const std::uint32_t account_id, LocateCB cb) 
 }
 
 void AccountClient::locate_account_id(const std::string& username, AccountCB cb) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	LookupIDT msg {
 		.account_name = username
@@ -59,8 +59,8 @@ void AccountClient::locate_account_id(const std::string& username, AccountCB cb)
 
 void AccountClient::handle_lookup_response(
 	std::expected<const AccountFetchResponse*, spark::Result> res,
-	const AccountCB& cb) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+const AccountCB& cb) const {
+	LOG_TRACE(logger_, log_func);
 
 	if(!res) {
 		cb(Status::rpc_error, {});
@@ -73,7 +73,7 @@ void AccountClient::handle_lookup_response(
 
 void AccountClient::handle_locate_response(std::expected<const SessionResponse*, spark::Result> res,
                                            const LocateCB& cb) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	if(!res) {
 		cb(Status::rpc_error, {});

--- a/src/realm/CharacterClient.cpp
+++ b/src/realm/CharacterClient.cpp
@@ -23,20 +23,20 @@ CharacterClient::CharacterClient(spark::Server& server, const ConfigStore& confi
 }
 
 void CharacterClient::on_link_up(const spark::Link& link) {
-	LOG_DEBUG_ASYNC(logger_, "Link up: {}", link.peer_banner);
+	LOG_DEBUG(logger_, "Link up: {}", link.peer_banner);
 	link_ = link;
 }
 
 void CharacterClient::on_link_down(const spark::Link& link) {
-	LOG_DEBUG_ASYNC(logger_, "Link down: {}", link.peer_banner);
+	LOG_DEBUG(logger_, "Link down: {}", link.peer_banner);
 }
 
 void CharacterClient::connect_failed(const std::string_view ip, const std::uint16_t port) {
-	LOG_INFO_ASYNC(logger_, "Failed to connect to character service on {}:{}", ip, port);
+	LOG_INFO(logger_, "Failed to connect to character service on {}:{}", ip, port);
 }
 
 void CharacterClient::retrieve_characters(const std::uint32_t account_id, RetrieveCB cb) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	const auto& config = config_store_.config();
 
@@ -53,7 +53,7 @@ void CharacterClient::retrieve_characters(const std::uint32_t account_id, Retrie
 void CharacterClient::create_character(const std::uint32_t account_id,
 									   const CharacterTemplateT& character,
 									   ResponseCB cb) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	const auto& config = config_store_.config();
 
@@ -70,7 +70,7 @@ void CharacterClient::create_character(const std::uint32_t account_id,
 void CharacterClient::delete_character(std::uint32_t account_id,
 									   std::uint64_t id,
 									   ResponseCB cb) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	const auto& config = config_store_.config();
 
@@ -89,7 +89,7 @@ void CharacterClient::rename_character(std::uint32_t account_id,
 									   std::uint64_t character_id,
 									   const utf8_string& name,
 									   RenameCB cb) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 	const auto& config = config_store_.config();
 
 	RenameT msg {
@@ -107,7 +107,7 @@ void CharacterClient::rename_character(std::uint32_t account_id,
 void CharacterClient::handle_create_reply(const spark::Link& link,
                                           std::expected<const CreateResponse*, spark::Result> res,
                                           ResponseCB cb) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	if(!res) {
 		cb(protocol::Result::char_create_error);
@@ -121,7 +121,7 @@ void CharacterClient::handle_create_reply(const spark::Link& link,
 void CharacterClient::handle_rename_reply(const spark::Link& link,
                                           std::expected<const RenameResponse*, spark::Result> res,
                                           RenameCB cb) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	if(!res) {
 		cb(protocol::Result::char_name_failure, 0, "");
@@ -141,7 +141,7 @@ void CharacterClient::handle_rename_reply(const spark::Link& link,
 void CharacterClient::handle_retrieve_reply(const spark::Link& link,
                                             std::expected<const RetrieveResponse*, spark::Result> res,
                                             RetrieveCB cb) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	if(!res) {
 		cb(Status::unknown_error, {});
@@ -196,7 +196,7 @@ void CharacterClient::handle_retrieve_reply(const spark::Link& link,
 void CharacterClient::handle_delete_reply(const spark::Link& link,
                                           std::expected<const DeleteResponse*, spark::Result> res,
                                           ResponseCB cb) const {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	if(!res) {
 		cb(protocol::Result::char_delete_failed);
@@ -204,7 +204,7 @@ void CharacterClient::handle_delete_reply(const spark::Link& link,
 	}
 
 	const auto msg = *res;
-	LOG_TRACE_ASYNC(logger_, "Result: {}", msg->result());
+	LOG_TRACE(logger_, "Result: {}", msg->result());
 	cb(protocol::Result(msg->result()));
 }
 

--- a/src/realm/ClientConnection.cpp
+++ b/src/realm/ClientConnection.cpp
@@ -20,7 +20,7 @@
 namespace ember::realm {
 
 void ClientConnection::parse_header() {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	if(inbound_buffer_.size() < protocol::ClientHeader::wire_size) {
 		return;
@@ -37,7 +37,7 @@ void ClientConnection::parse_header() {
 	>(msg_size_);
 
 	if(msg_size_ < sizeof(protocol::ClientHeader::OpcodeType)) {
-		LOG_DEBUG_ASYNC(logger_, "Invalid message size from {}", remote_address());
+		LOG_DEBUG(logger_, "Invalid message size from {}", remote_address());
 		close_session();
 		return;
 	}
@@ -134,7 +134,7 @@ void ClientConnection::read() {
 	// If there's partially processed data in the buffer, we may be
 	// able to free space by defragmenting it.
 	if(inbound_buffer_.free() < required_space && !inbound_buffer_.defragment()) [[unlikely]] {
-		LOG_DEBUG_ASYNC(logger_, "Inbound buffer full, closing {}", remote_address());
+		LOG_DEBUG(logger_, "Inbound buffer full, closing {}", remote_address());
 		close_session();
 		return;
 	}
@@ -179,7 +179,7 @@ void ClientConnection::stop() {
 		return;
 	}
 
-	LOG_DEBUG_ASYNC(logger_, "Closing connection to {}", remote_address());
+	LOG_DEBUG(logger_, "Closing connection to {}", remote_address());
 	boost::system::error_code ec; // we don't care about any errors
 	socket_.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
 	socket_.close(ec);

--- a/src/realm/ClientConnection.inl
+++ b/src/realm/ClientConnection.inl
@@ -43,18 +43,18 @@ bool ClientConnection::write_packet_stream(const PacketType& packet) {
 }
 
 void ClientConnection::send(const is_packet auto& packet) {
-	LOG_TRACE_ASYNC(logger_,"{} <- {}", remote_address(), protocol::to_string(packet.opcode));
+	LOG_TRACE(logger_,"{} <- {}", remote_address(), protocol::to_string(packet.opcode));
 
 	// we're in a bad state if writing fails, we can't recover
 	if(!write_packet_stream(packet)) [[unlikely]] {
-		LOG_WARN_ASYNC(logger_, "Failed to write packet to stream");
+		LOG_WARN(logger_, "Failed to write packet to stream");
 		close_session();
 		return;
 	}
 
 	// the buffer size is dynamic, so ensure it isn't growing too large
 	if(outbound_back_->size() > max_outbound_size) {
-		LOG_DEBUG_ASYNC(logger_, "Outbound buffer too large, dropping client");
+		LOG_DEBUG(logger_, "Outbound buffer too large, dropping client");
 		close_session();
 		return;
 	}

--- a/src/realm/ClientHandler.cpp
+++ b/src/realm/ClientHandler.cpp
@@ -79,7 +79,7 @@ void ClientHandler::skip(BinaryStream& stream) {
 }
 
 void ClientHandler::handle_ping(BinaryStream& stream) {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	protocol::cmsg_ping packet;
 

--- a/src/realm/ClientHandler.inl
+++ b/src/realm/ClientHandler.inl
@@ -19,7 +19,7 @@ namespace ember::realm {
 bool ClientHandler::deserialise(is_packet auto& packet, BinaryStream& stream) {
 	if(auto result = packet.read_payload_from_stream(stream); result) {
 		if(stream.read_limit() != stream.total_read()) {
-			LOG_DEBUG_ASYNC(
+			LOG_DEBUG(
 				logger_, "Skipping unprocessed data in message {} from {}",
 				protocol::to_string(packet.opcode), client_identify()
 			);
@@ -29,7 +29,7 @@ bool ClientHandler::deserialise(is_packet auto& packet, BinaryStream& stream) {
 
 		return true;
 	} else {
-		LOG_TRACE_ASYNC(logger_, "Unexpected stream result: {} ({})", result.value(), result.what());
+		LOG_TRACE(logger_, "Unexpected stream result: {} ({})", result.value(), result.what());
 	}
 
 	/*
@@ -46,7 +46,7 @@ bool ClientHandler::deserialise(is_packet auto& packet, BinaryStream& stream) {
 	 */
 	switch(stream.state()) {
 		case spark::io::StreamState::read_limit_error:
-			LOG_DEBUG_ASYNC(
+			LOG_DEBUG(
 				logger_, "Deserialisation of {} failed, skipping any remaining data",
 				protocol::to_string(packet.opcode)
 			);
@@ -54,7 +54,7 @@ bool ClientHandler::deserialise(is_packet auto& packet, BinaryStream& stream) {
 			stream.skip(stream.read_limit() - stream.total_read());
 			break;
 		case spark::io::StreamState::buffer_limit_error:
-			LOG_ERROR_ASYNC(
+			LOG_ERROR(
 				logger_, "Message framing lost for {} from {}",
 				protocol::to_string(packet.opcode), client_identify()
 			);
@@ -62,7 +62,7 @@ bool ClientHandler::deserialise(is_packet auto& packet, BinaryStream& stream) {
 			close();
 			break;
 		default:
-			LOG_ERROR_ASYNC(logger_,
+			LOG_ERROR(logger_,
 				"Deserialisation failed, stream state {}, unhandled error for {} from {}",
 				std::to_underlying(stream.state()), protocol::to_string(packet.opcode), client_identify()
 			);

--- a/src/realm/ClientLogHelper.h
+++ b/src/realm/ClientLogHelper.h
@@ -11,22 +11,22 @@
 #include <logger/Logger.h>
 
 #define CLIENT_TRACE(logger, ctx) \
-	LOG_TRACE(logger) << ctx.handler.client_identify() << ": "
+	LOG_TRACE_STREAM(logger) << ctx.handler.client_identify() << ": "
 
 #define CLIENT_DEBUG(logger, ctx) \
-	LOG_DEBUG(logger) << ctx.handler.client_identify() << ": "
+	LOG_DEBUG_STREAM(logger) << ctx.handler.client_identify() << ": "
 
 #define CLIENT_INFO(logger, ctx) \
-	LOG_INFO(logger) << ctx.handler.client_identify() << ": "
+	LOG_INFO_STREAM(logger) << ctx.handler.client_identify() << ": "
 
 #define CLIENT_WARN(logger, ctx) \
-    LOG_WARN(logger) << ctx.handler.client_identify() << ": "
+    LOG_WARN_STREAM(logger) << ctx.handler.client_identify() << ": "
 
 #define CLIENT_ERROR(logger, ctx) \
-	LOG_ERROR(logger) << ctx.handler.client_identify() << ": "
+	LOG_ERROR_STREAM(logger) << ctx.handler.client_identify() << ": "
 
 #define CLIENT_FATAL(logger, ctx) \
-	LOG_FATAL(logger) << ctx.handler.client_identify() << ": "
+	LOG_FATAL_STREAM(logger) << ctx.handler.client_identify() << ": "
 
 #define CLIENT_TRACE_GLOB(ctx) \
 	CLIENT_TRACE(ember::log::global_logger(), ctx)

--- a/src/realm/EventDispatcher.cpp
+++ b/src/realm/EventDispatcher.cpp
@@ -20,7 +20,7 @@ void EventDispatcher::post_event(const ClientIdent& client, std::unique_ptr<Even
 
 	// bad service index encoded in the UUID
 	if(service == nullptr) {
-		LOG_ERROR_ASYNC(logger_, "Invalid service index, {}", client.service());
+		LOG_ERROR(logger_, "Invalid service index, {}", client.service());
 		return;
 	}
 
@@ -28,7 +28,7 @@ void EventDispatcher::post_event(const ClientIdent& client, std::unique_ptr<Even
 		if(auto handler = handlers_.find(client); handler != handlers_.end()) {
 			handler->second->handle_event(event.get());
 		} else {
-			LOG_DEBUG_ASYNC(logger_, "Client disconnected, event discarded");
+			LOG_DEBUG(logger_, "Client disconnected, event discarded");
 		}
 	});
 }
@@ -73,7 +73,7 @@ void EventDispatcher::broadcast_event(std::vector<ClientIdent> clients, std::sha
 				if(auto handler = handlers_.find(*beg++); handler != handlers_.end()) {
 					handler->second->handle_event(event.get());
 				} else {
-					LOG_DEBUG_ASYNC(logger_, "Client disconnected, event discarded");
+					LOG_DEBUG(logger_, "Client disconnected, event discarded");
 				}
 			}
 		});

--- a/src/realm/EventDispatcher.h
+++ b/src/realm/EventDispatcher.h
@@ -41,13 +41,13 @@ public:
 
 		// bad service index encoded in the UUID
 		if(service == nullptr) {
-			LOG_ERROR_ASYNC(logger_, "Invalid service index, {}", client.service());
+			LOG_ERROR(logger_, "Invalid service index, {}", client.service());
 			return;
 		}
 
 		boost::asio::post(*service, [&, client, work = std::move(work)] {
 			if(!handlers_.contains(client)) {
-				LOG_DEBUG_ASYNC(logger_, "Client disconnected, work discarded");
+				LOG_DEBUG(logger_, "Client disconnected, work discarded");
 				return;
 			}
 
@@ -60,7 +60,7 @@ public:
 
 		// bad service index encoded in the UUID
 		if(service == nullptr) {
-			LOG_ERROR_ASYNC(logger_, "Invalid service index, {}", client.service());
+			LOG_ERROR(logger_, "Invalid service index, {}", client.service());
 			return;
 		}
 
@@ -69,7 +69,7 @@ public:
 				auto& [_, handler] = *it;
 				handler->handle_event(&event);
 			} else {
-				LOG_DEBUG_ASYNC(logger_, "Client disconnected, event discarded");
+				LOG_DEBUG(logger_, "Client disconnected, event discarded");
 			}
 		});
 	}

--- a/src/realm/LoggingCallbacks.h
+++ b/src/realm/LoggingCallbacks.h
@@ -21,23 +21,23 @@ inline void forward_log_callback(ports::Severity severity, const std::string_vie
 
 	switch(severity) {
 		case ports::Severity::debug:
-			LOG_DEBUG_ASYNC(logger, fmt, message);
+			LOG_DEBUG(logger, fmt, message);
 			break;
 		case ports::Severity::info:
-			LOG_INFO_ASYNC(logger, fmt, message);
+			LOG_INFO(logger, fmt, message);
 			break;
 		case ports::Severity::warn:
-			LOG_WARN_ASYNC(logger, fmt, message);
+			LOG_WARN(logger, fmt, message);
 			break;
 		case ports::Severity::error:
-			LOG_ERROR_ASYNC(logger, fmt, message);
+			LOG_ERROR(logger, fmt, message);
 			break;
 		case ports::Severity::fatal:
-			LOG_FATAL_ASYNC(logger, fmt, message);
+			LOG_FATAL(logger, fmt, message);
 			break;
 		default:
-			LOG_ERROR_ASYNC(logger, "Unhandled port forward log callback severity");
-			LOG_ERROR_ASYNC(logger, fmt, message);
+			LOG_ERROR(logger, "Unhandled port forward log callback severity");
+			LOG_ERROR(logger, fmt, message);
 	}
 }
 
@@ -47,26 +47,26 @@ inline static void stun_log_callback(stun::Severity severity, stun::Error reason
 
 	switch(severity) {
 		case stun::Severity::trace:
-			LOG_TRACE_SYNC(logger, fmt, reason_str);
+			SLOG_TRACE(logger, fmt, reason_str);
 			break;
 		case stun::Severity::debug:
-			LOG_DEBUG_SYNC(logger, fmt, reason_str);
+			SLOG_DEBUG(logger, fmt, reason_str);
 			break;
 		case stun::Severity::info:
-			LOG_INFO_SYNC(logger, fmt, reason_str);
+			SLOG_INFO(logger, fmt, reason_str);
 			break;
 		case stun::Severity::warn:
-			LOG_WARN_SYNC(logger, fmt, reason_str);
+			SLOG_WARN(logger, fmt, reason_str);
 			break;
 		case stun::Severity::error:
-			LOG_ERROR_SYNC(logger, fmt, reason_str);
+			SLOG_ERROR(logger, fmt, reason_str);
 			break;
 		case stun::Severity::fatal:
-			LOG_FATAL_SYNC(logger, fmt, reason_str);
+			SLOG_FATAL(logger, fmt, reason_str);
 			break;
 		default:
-			LOG_ERROR_ASYNC(logger, "Unhandled STUN log callback severity");
-			LOG_ERROR_SYNC(logger, fmt, reason_str);
+			LOG_ERROR(logger, "Unhandled STUN log callback severity");
+			SLOG_ERROR(logger, fmt, reason_str);
 	}
 }
 
@@ -75,23 +75,23 @@ inline void pool_log_callback(connection_pool::Severity severity, std::string_vi
 
 	switch(severity) {
 		case connection_pool::Severity::debug:
-			LOG_DEBUG_ASYNC(logger, fmt, message);
+			LOG_DEBUG(logger, fmt, message);
 			break;
 		case connection_pool::Severity::info:
-			LOG_INFO_ASYNC(logger, fmt, message);
+			LOG_INFO(logger, fmt, message);
 			break;
 		case connection_pool::Severity::warn:
-			LOG_WARN_ASYNC(logger, fmt, message);
+			LOG_WARN(logger, fmt, message);
 			break;
 		case connection_pool::Severity::error:
-			LOG_ERROR_ASYNC(logger, fmt, message);
+			LOG_ERROR(logger, fmt, message);
 			break;
 		case connection_pool::Severity::fatal:
-			LOG_FATAL_ASYNC(logger, fmt, message);
+			LOG_FATAL(logger, fmt, message);
 			break;
 		default:
-			LOG_ERROR_ASYNC(logger, "Unhandled connection pool log callback severity");
-			LOG_ERROR_ASYNC(logger, fmt, message);
+			LOG_ERROR(logger, "Unhandled connection pool log callback severity");
+			LOG_ERROR(logger, fmt, message);
 	}
 }
 

--- a/src/realm/NetworkListener.cpp
+++ b/src/realm/NetworkListener.cpp
@@ -17,7 +17,7 @@
 namespace ember::realm {
 
 void NetworkListener::accept_connection() {
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 
 	if(!acceptor_.is_open()) {
 		return;
@@ -31,7 +31,7 @@ void NetworkListener::accept_connection() {
 		if(!ec) {
 			dispatch_socket();
 		} else {
-			LOG_DEBUG_ASYNC(logger_, "Unable to accept connection, {}", ec.message());
+			LOG_DEBUG(logger_, "Unable to accept connection, {}", ec.message());
 		}
 
 		++index_;
@@ -46,7 +46,7 @@ void NetworkListener::dispatch_socket() {
 	const auto ep = socket_.remote_endpoint(ec);
 
 	if(!ec) {
-		LOG_DEBUG_ASYNC(logger_, "Accepted connection from {}", ep.address().to_string());
+		LOG_DEBUG(logger_, "Accepted connection from {}", ep.address().to_string());
 		auto executor = socket_.get_executor();
 
 		boost::asio::dispatch(executor, [&, socket = std::move(socket_), i = index_]() mutable {
@@ -54,7 +54,7 @@ void NetworkListener::dispatch_socket() {
 			sessions_.start(std::move(client));
 		});
 	} else {
-		LOG_DEBUG_ASYNC(logger_, "Aborted connection, remote peer disconnected");
+		LOG_DEBUG(logger_, "Aborted connection, remote peer disconnected");
 	}
 }
 
@@ -65,7 +65,7 @@ void NetworkListener::shutdown() {
 		return;
 	}
 
-	LOG_TRACE(logger_) << log_func << LOG_ASYNC;
+	LOG_TRACE(logger_, log_func);
 	acceptor_.close();
 }
 

--- a/src/realm/RealmService.cpp
+++ b/src/realm/RealmService.cpp
@@ -20,14 +20,14 @@ RealmService::RealmService(Server& server, Realm realm, log::Logger& logger)
 	  logger_(logger) { }
 
 void RealmService::on_link_up(const Link& link) {
-	LOG_DEBUG_ASYNC(logger_, "Link up: {}", link.peer_banner);
+	LOG_DEBUG(logger_, "Link up: {}", link.peer_banner);
 
 	std::lock_guard guard(mutex);
 	links_.emplace_back(link);
 }
 
 void RealmService::on_link_down(const Link& link) {
-	LOG_DEBUG_ASYNC(logger_, "Link closed: {}", link.peer_banner);
+	LOG_DEBUG(logger_, "Link closed: {}", link.peer_banner);
 
 	std::lock_guard guard(mutex);
 

--- a/src/realm/Service.cpp
+++ b/src/realm/Service.cpp
@@ -75,11 +75,11 @@ int Service::run(const opts::variables_map& args) try {
 
 	if(!concurrency) {
 		concurrency = thread::hardware_concurrency([&](auto msg) {
-			LOG_ERROR_SYNC(logger, msg);
+			SLOG_ERROR(logger, msg);
 		});
 	}
 
-	LOG_INFO_SYNC(logger, "Starting service pool with {} threads", concurrency);
+	SLOG_INFO(logger, "Starting service pool with {} threads", concurrency);
 	auto ctx = context.get();
 	ctx->service_pool = std::make_unique<thread::ServicePool>(
 		concurrency, BOOST_ASIO_CONCURRENCY_HINT_UNSAFE_IO
@@ -94,10 +94,10 @@ int Service::run(const opts::variables_map& args) try {
 	ctx->service_pool->run();
 	runner.join();
 
-	LOG_INFO_SYNC(logger, "{} stopped", app_name);
+	SLOG_INFO(logger, "{} stopped", app_name);
 	return EXIT_SUCCESS;
 } catch(const std::exception& e) {
-	LOG_FATAL_SYNC(logger, e.what());
+	SLOG_FATAL(logger, e.what());
 	return EXIT_FAILURE;
 }
 
@@ -114,7 +114,7 @@ void Service::initialise(const opts::variables_map& args) try {
 		builds += to_string(client) + " ";
 	}
 
-	LOG_INFO_SYNC(logger, "Allowed client builds: {}", builds);
+	SLOG_INFO(logger, "Allowed client builds: {}", builds);
 
 	auto stun = create_stun_client(args);
 	const auto stun_enabled = args["stun.enabled"].as<bool>();
@@ -127,25 +127,25 @@ void Service::initialise(const opts::variables_map& args) try {
 			stun_log_callback(severity, reason, logger);
 		});
 
-		LOG_INFO_SYNC(logger, "Starting STUN query...");
+		SLOG_INFO(logger, "Starting STUN query...");
 		stun_res = stun.external_address();
 	}
 
-	LOG_INFO_SYNC(logger, "Seeding xorshift RNG...");
+	SLOG_INFO(logger, "Seeding xorshift RNG...");
 	seed_xorshift_rng();
 
-	LOG_INFO_SYNC(logger, "Loading DBC data...");
+	SLOG_INFO(logger, "Loading DBC data...");
 	dbc::DiskLoader loader(args["dbc.path"].as<std::string>(), [&](auto message) {
-		LOG_DEBUG(logger) << message << LOG_SYNC;
+		SLOG_DEBUG(logger, message);
 	});
 
 	ctx->dbcs = std::make_unique<dbc::Storage>(std::move(loader.load(dbcs_required)));
 
-	LOG_INFO_SYNC(logger, "Resolving DBC references...");
+	SLOG_INFO(logger, "Resolving DBC references...");
 	dbc::link(*ctx->dbcs);
 
 	const auto realm_id = args["realm.id"].as<unsigned int>();
-	LOG_INFO_SYNC(logger, "Loading configuration for realm ID {}", realm_id);
+	SLOG_INFO(logger, "Loading configuration for realm ID {}", realm_id);
 
 	if(auto realm = load_realm(args, logger)) {
 		ctx->realm = std::make_unique<Realm>(std::move(*realm));
@@ -160,12 +160,12 @@ void Service::initialise(const opts::variables_map& args) try {
 
 	// Validate category & region
 	const auto& cat_name = category_name(*ctx->realm, ctx->dbcs->cfg_categories);
-	LOG_INFO_SYNC(logger, "Serving as realm for {} ({})", ctx->realm->name, cat_name);
+	SLOG_INFO(logger, "Serving as realm for {} ({})", ctx->realm->name, cat_name);
 
-	LOG_INFO_SYNC(logger, "Starting event dispatcher...");
+	SLOG_INFO(logger, "Starting event dispatcher...");
 	ctx->dispatcher = std::make_unique<EventDispatcher>(*ctx->service_pool, logger);
 
-	LOG_INFO_SYNC(logger, "Starting Spark service...");
+	SLOG_INFO(logger, "Starting Spark service...");
 	const auto& s_address = args["spark.address"].as<std::string>();
 	auto s_port = args["spark.port"].as<std::uint16_t>();
 
@@ -179,7 +179,7 @@ void Service::initialise(const opts::variables_map& args) try {
 
 	// If the port specified in the database differs from the config file, use the config file
 	if(port != ctx->realm->port) {
-		LOG_WARN_SYNC(
+		SLOG_WARN(
 			logger, "Configured port {} differs from database entry port {}, using {}",
 			port, ctx->realm->port, port
 		);
@@ -190,7 +190,7 @@ void Service::initialise(const opts::variables_map& args) try {
 
 	// Retrieve STUN result
 	if(stun_enabled) {
-		LOG_INFO_SYNC(logger, "Waiting on STUN result...");
+		SLOG_INFO(logger, "Waiting on STUN result...");
 
 		const auto result = stun_res.get();
 		log_stun_result(stun, result, port, logger);
@@ -201,7 +201,7 @@ void Service::initialise(const opts::variables_map& args) try {
 		}
 	}
 
-	LOG_INFO_SYNC(logger, "Realm will be advertised on {}", ctx->realm->address);
+	SLOG_INFO(logger, "Realm will be advertised on {}", ctx->realm->address);
 
 	// Start port forwarding
 	auto& service = ctx->service_pool->get(0);
@@ -222,7 +222,7 @@ void Service::initialise(const opts::variables_map& args) try {
 	ctx->config_store = std::make_unique<ConfigStore>(config);
 	update_config(config, true);
 
-	LOG_INFO_SYNC(logger, "Starting RPC services...");
+	SLOG_INFO(logger, "Starting RPC services...");
 	ctx->rpc = std::make_unique<spark::Server>(service, app_name, s_address, s_port, logger);
 	ctx->rpc_realm = std::make_unique<RealmService>(*ctx->rpc, *ctx->realm, logger);
 	ctx->rpc_account= std::make_unique<AccountClient>(*ctx->rpc, logger);
@@ -246,23 +246,23 @@ void Service::initialise(const opts::variables_map& args) try {
 
 	// Misc. information
 	const auto max_socks = utility::max_sockets_desc();
-	LOG_INFO_SYNC(logger, "Max allowed sockets: {}", max_socks);
+	SLOG_INFO(logger, "Max allowed sockets: {}", max_socks);
 
 	// Start network listener
-	LOG_INFO_SYNC(logger, "Starting network service on {}:{}...", interface, port);
+	SLOG_INFO(logger, "Starting network service on {}:{}...", interface, port);
 	ctx->server = std::make_unique<NetworkListener>(
 		*ctx->service_pool, ctx->sessions, interface, port, tcp_no_delay, logger
 	);
 	
 	// Install service command handlers
-	LOG_INFO_SYNC(logger, "Registering command handlers...");
+	SLOG_INFO(logger, "Registering command handlers...");
 	register_commands(service);
 
 	// All done setting up
 	boost::asio::dispatch(service, [&, time, ctx]() {
 		ctx->rpc_realm->set_online();
 
-		LOG_INFO_SYNC(logger, "{} started successfully in {}", app_name,
+		SLOG_INFO(logger, "{} started successfully in {}", app_name,
 			utility::time_elapsed_format(time));
 
 		start_time = std::chrono::steady_clock::now();
@@ -277,7 +277,7 @@ void Service::register_commands(boost::asio::io_context& ioc) {
 
 	ctx->cmd_exec = std::make_unique<utility::CommandExecutor>(
 		ioc, [&](auto reason) {
-			LOG_CONSOLE_ERROR_ASYNC(logger, "Command could not be executed, {}", reason);
+			LOG_CONERR(logger, "Command could not be executed, {}", reason);
 		}
 	);
 
@@ -296,9 +296,9 @@ void Service::register_commands(boost::asio::io_context& ioc) {
 			try {
 				const auto config = generate_config(reload_options(config_file));
 				update_config(config);
-				LOG_CONSOLE_ASYNC(logger, "Configuration file successfully reloaded");
+				LOG_CONSOLE(logger, "Configuration file successfully reloaded");
 			} catch(const std::exception& e) {
-				LOG_CONSOLE_ERROR_ASYNC(logger, "Could not reload configuration, '{}'", e.what());
+				LOG_CONERR(logger, "Could not reload configuration, '{}'", e.what());
 			}
 		})
 	));
@@ -349,11 +349,11 @@ Config Service::generate_config(const opts::variables_map& args) {
  * connections elsewhere in the future, this should be merged back.
  */
 std::optional<Realm> load_realm(const opts::variables_map& args, log::Logger& logger) {
-	LOG_INFO_SYNC(logger, "Initialising database driver...");
+	SLOG_INFO(logger, "Initialising database driver...");
 	const auto& db_config_path = args["database.config_path"].as<std::string>();
 	auto driver(drivers::init_db_driver(db_config_path, "login"));
 
-	LOG_INFO_SYNC(logger, "Initialising database connection pool...");
+	SLOG_INFO(logger, "Initialising database connection pool...");
 
 	connection_pool::PoolImpl<drivers::AutoSelect, connection_pool::CheckinClean, connection_pool::ExponentialGrowth> pool(
 		std::move(driver), 1, 1, 30s
@@ -363,10 +363,10 @@ std::optional<Realm> load_realm(const opts::variables_map& args, log::Logger& lo
 		pool_log_callback(severity, message, logger);
 	});
 
-	LOG_INFO_SYNC(logger, "Initialising DAOs...");
+	SLOG_INFO(logger, "Initialising DAOs...");
 	auto realm_dao = dal::realm_dao(pool);
 
-	LOG_INFO_SYNC(logger, "Retrieving realm information...");
+	SLOG_INFO(logger, "Retrieving realm information...");
 	return realm_dao.get_realm(args["realm.id"].as<unsigned int>());
 }
 
@@ -383,7 +383,7 @@ void Service::stop() {
 		return;
 	}
 
-	LOG_TRACE_SYNC(logger, "{} shutting down...", app_name);
+	SLOG_TRACE(logger, "{} shutting down...", app_name);
 	auto ctx = context.get();
 
 	boost::asio::post(ctx->service_pool->get(0), [&] {
@@ -400,7 +400,7 @@ Service::~Service() {
 }
 
 void print_lib_versions(log::Logger& logger) {
-	LOG_DEBUG(logger)
+	LOG_DEBUG_STREAM(logger)
 		<< "Compiled with library versions: " << "\n"
 		<< " - Boost " << BOOST_VERSION / 100000 << "."
 		<< BOOST_VERSION / 100 % 1000 << "."

--- a/src/realm/WorldRPCClient.cpp
+++ b/src/realm/WorldRPCClient.cpp
@@ -21,7 +21,7 @@ WorldRPCClient::WorldRPCClient(spark::Server& spark, log::Logger& logger)
 }
 
 void WorldRPCClient::connect_failed(const std::string_view ip, std::uint16_t port) {
-	LOG_INFO_ASYNC(logger_, "Failed to connect to world service on {}:{}", ip, port);
+	LOG_INFO(logger_, "Failed to connect to world service on {}:{}", ip, port);
 }
 
 void WorldRPCClient::handle_get_status_response(const Link& link, const Status& msg) {
@@ -45,11 +45,11 @@ void WorldRPCClient::handle_player_leave_response(const Link& link, const Player
 }
 
 void WorldRPCClient::on_link_up(const Link& link) {
-	LOG_DEBUG_ASYNC(logger_, "Link up: {}", link.peer_banner);
+	LOG_DEBUG(logger_, "Link up: {}", link.peer_banner);
 }
 
 void WorldRPCClient::on_link_down(const Link& link) {
-	LOG_DEBUG_ASYNC(logger_, "Link down: {}", link.peer_banner);
+	LOG_DEBUG(logger_, "Link down: {}", link.peer_banner);
 }
 
 } // realm, ember

--- a/src/realm/main.cpp
+++ b/src/realm/main.cpp
@@ -47,16 +47,16 @@ int main(int argc, const char* argv[]) try {
 	log::Logger logger;
 	utility::configure_logger(logger, args);
 	log::global_logger(logger);
-	LOG_INFO_SYNC(logger, "Logger configured successfully");
+	SLOG_INFO(logger, "Logger configured successfully");
 
-	LOG_DEBUG_SYNC(logger, "Registering command handlers...");
+	SLOG_DEBUG(logger, "Registering command handlers...");
 	const auto suggestions = args["console_log.suggestions"].as<bool>();
 	commands::Registry registry;
 	utility::register_command_handlers(registry, logger, suggestions);
 	utility::register_shared_commands(registry, logger);
 
 	const auto ret = run(args, logger, registry);
-	LOG_INFO_SYNC(logger, "{} terminated (returned '{}')", realm::app_name, ret);
+	SLOG_INFO(logger, "{} terminated (returned '{}')", realm::app_name, ret);
 	return ret;
 } catch(const std::exception& e) {
 	std::cerr << e.what();
@@ -74,7 +74,7 @@ int run(const opts::variables_map& args, log::Logger& logger, commands::Registry
 			return;
 		}
 
-		LOG_DEBUG_SYNC(logger, "Received signal {}({})", utility::sig_str(signal), signal);
+		SLOG_DEBUG(logger, "Received signal {}({})", utility::sig_str(signal), signal);
 		signals.clear();
 		service.stop();
 	});
@@ -88,7 +88,7 @@ int run(const opts::variables_map& args, log::Logger& logger, commands::Registry
 	signals.cancel();
 	return ret;
 } catch(const std::exception& e) {
-	LOG_FATAL_SYNC(logger, e.what());
+	SLOG_FATAL(logger, e.what());
 	return EXIT_FAILURE;
 }
 

--- a/src/realm/states/Authentication.cpp
+++ b/src/realm/states/Authentication.cpp
@@ -62,7 +62,7 @@ State auth_state(ClientContext& ctx) {
 }
 
 void handle_authentication(ClientContext& ctx) {
-	LOG_TRACE(ctx.logger) << log_func << LOG_ASYNC;
+	LOG_TRACE(ctx.logger, log_func);
 
 	// prevent repeated auth attempts
 	if(auth_state(ctx) != State::not_authed) {
@@ -102,7 +102,7 @@ void handle_authentication(ClientContext& ctx) {
 }
 
 void fetch_account_id(const ClientContext& ctx, const utf8_string& username) {
-	LOG_TRACE(ctx.logger) << log_func << LOG_ASYNC;
+	LOG_TRACE(ctx.logger, log_func);
 
 	const auto& uuid = ctx.handler.uuid();
 
@@ -113,7 +113,7 @@ void fetch_account_id(const ClientContext& ctx, const utf8_string& username) {
 }
 
 void handle_account_id(ClientContext& ctx, const AccountIDResponse* event) {
-	LOG_TRACE(ctx.logger) << log_func << LOG_ASYNC;
+	LOG_TRACE(ctx.logger, log_func);
 	
 	auto& auth_ctx = std::get<Context>(ctx.state_ctx);
 
@@ -141,7 +141,7 @@ void handle_account_id(ClientContext& ctx, const AccountIDResponse* event) {
 }
 
 void fetch_session_key(const ClientContext& ctx, const std::uint32_t account_id) {
-	LOG_TRACE(ctx.logger) << log_func << LOG_ASYNC;
+	LOG_TRACE(ctx.logger, log_func);
 
 	const auto& uuid = ctx.handler.uuid();
 
@@ -168,7 +168,7 @@ void handle_session_key(ClientContext& ctx, const SessionKeyResponse* event) {
 }
 
 void prove_session(ClientContext& ctx, const Botan::BigInt& key) {
-	LOG_TRACE(ctx.logger) << log_func << LOG_ASYNC;
+	LOG_TRACE(ctx.logger, log_func);
 
 	// Encode the key without requiring an allocation
 	static constexpr auto key_size_hint = 40u;
@@ -214,7 +214,7 @@ void prove_session(ClientContext& ctx, const Botan::BigInt& key) {
 }
 
 void send_auth_challenge(ClientContext& ctx) {
-	LOG_TRACE(ctx.logger) << log_func << LOG_ASYNC;
+	LOG_TRACE(ctx.logger, log_func);
 
 	auto& auth_ctx = std::get<Context>(ctx.state_ctx);
 	protocol::smsg_auth_challenge response;
@@ -223,7 +223,7 @@ void send_auth_challenge(ClientContext& ctx) {
 }
 
 void send_addon_data(ClientContext& ctx) {
-	LOG_TRACE(ctx.logger) << log_func << LOG_ASYNC;
+	LOG_TRACE(ctx.logger, log_func);
 
 	const auto& auth_ctx = std::get<Context>(ctx.state_ctx);
 	const auto& addons = auth_ctx.packet->addons;
@@ -252,7 +252,7 @@ void send_addon_data(ClientContext& ctx) {
 }
 
 void auth_queue(ClientContext& ctx) {
-	LOG_TRACE(ctx.logger) << log_func << LOG_ASYNC;
+	LOG_TRACE(ctx.logger, log_func);
 
 	const auto& uuid = ctx.handler.uuid();
 
@@ -272,7 +272,7 @@ void auth_queue(ClientContext& ctx) {
 }
 
 void auth_success(ClientContext& ctx) {
-	LOG_TRACE(ctx.logger) << log_func << LOG_ASYNC;
+	LOG_TRACE(ctx.logger, log_func);
 
 	send_auth_result(ctx, protocol::Result::auth_ok);
 	send_addon_data(ctx);
@@ -282,7 +282,7 @@ void auth_success(ClientContext& ctx) {
 }
 
 void send_auth_result(ClientContext& ctx, protocol::Result result) {
-	LOG_TRACE(ctx.logger) << log_func << LOG_ASYNC;
+	LOG_TRACE(ctx.logger, log_func);
 
 	protocol::smsg_auth_response response;
 	response->result = result;
@@ -290,7 +290,7 @@ void send_auth_result(ClientContext& ctx, protocol::Result result) {
 }
 
 void handle_queue_update(ClientContext& ctx, const QueuePosition* event) {
-	LOG_TRACE(ctx.logger) << log_func << LOG_ASYNC;
+	LOG_TRACE(ctx.logger, log_func);
 
 	protocol::smsg_auth_response packet;
 	packet->result = protocol::Result::auth_wait_queue;
@@ -299,7 +299,7 @@ void handle_queue_update(ClientContext& ctx, const QueuePosition* event) {
 }
 
 void handle_queue_success(ClientContext& ctx) {
-	LOG_TRACE(ctx.logger) << log_func << LOG_ASYNC;
+	LOG_TRACE(ctx.logger, log_func);
 	auth_success(ctx);
 }
 

--- a/src/realm/states/CharacterList.cpp
+++ b/src/realm/states/CharacterList.cpp
@@ -34,7 +34,7 @@ namespace {
 void handle_timeout(ClientContext& ctx);
 
 void send_character_list_fail(ClientContext& ctx) {
-	LOG_TRACE(ctx.logger) << log_func << LOG_ASYNC;
+	LOG_TRACE(ctx.logger, log_func);
 
 	// displays an error dialogue on the client
 	protocol::smsg_char_create response;
@@ -43,7 +43,7 @@ void send_character_list_fail(ClientContext& ctx) {
 }
 
 void send_character_list(ClientContext& ctx, std::vector<Character> characters) {
-	LOG_TRACE(ctx.logger) << log_func << LOG_ASYNC;
+	LOG_TRACE(ctx.logger, log_func);
 
 	protocol::smsg_char_enum response;
 	response->characters = std::move(characters);
@@ -51,7 +51,7 @@ void send_character_list(ClientContext& ctx, std::vector<Character> characters) 
 }
 
 void send_character_rename(ClientContext& ctx, const CharRenameResponse* res) {
-	LOG_TRACE(ctx.logger) << log_func << LOG_ASYNC;
+	LOG_TRACE(ctx.logger, log_func);
 
 	protocol::smsg_char_rename response;
 	response->result = res->result;
@@ -61,7 +61,7 @@ void send_character_rename(ClientContext& ctx, const CharRenameResponse* res) {
 }
 
 void character_rename(ClientContext& ctx) {
-	LOG_TRACE(ctx.logger) << log_func << LOG_ASYNC;
+	LOG_TRACE(ctx.logger, log_func);
 
 	protocol::cmsg_char_rename packet;
 
@@ -79,7 +79,7 @@ void character_rename(ClientContext& ctx) {
 }
 
 void character_enumerate(const ClientContext& ctx) {
-	LOG_TRACE(ctx.logger) << log_func << LOG_ASYNC;
+	LOG_TRACE(ctx.logger, log_func);
 
 	const auto& uuid = ctx.handler.uuid();
 	Locator::character()->retrieve_characters(ctx.client_id->id,
@@ -91,7 +91,7 @@ void character_enumerate(const ClientContext& ctx) {
 }
 
 void character_enumerate_completion(ClientContext& ctx, const CharEnumResponse* event) {
-	LOG_TRACE(ctx.logger) << log_func << LOG_ASYNC;
+	LOG_TRACE(ctx.logger, log_func);
 
 	if(event->status == rpc::Character::Status::ok) {
 		send_character_list(ctx, event->characters);
@@ -101,7 +101,7 @@ void character_enumerate_completion(ClientContext& ctx, const CharEnumResponse* 
 }
 
 void send_character_delete(ClientContext& ctx, const CharDeleteResponse* res) {
-	LOG_TRACE(ctx.logger) << log_func << LOG_ASYNC;
+	LOG_TRACE(ctx.logger, log_func);
 
 	protocol::smsg_char_delete response;
 	response->result = res->result;
@@ -109,7 +109,7 @@ void send_character_delete(ClientContext& ctx, const CharDeleteResponse* res) {
 }
 
 void send_character_create(ClientContext& ctx, const CharCreateResponse* res) {
-	LOG_TRACE(ctx.logger) << log_func << LOG_ASYNC;
+	LOG_TRACE(ctx.logger, log_func);
 
 	protocol::smsg_char_create response;
 	response->result = res->result;
@@ -117,7 +117,7 @@ void send_character_create(ClientContext& ctx, const CharCreateResponse* res) {
 }
 
 void character_create(ClientContext& ctx) {
-	LOG_TRACE(ctx.logger) << log_func << LOG_ASYNC;
+	LOG_TRACE(ctx.logger, log_func);
 
 	protocol::cmsg_char_create packet;
 
@@ -133,7 +133,7 @@ void character_create(ClientContext& ctx) {
 }
 
 void character_delete(ClientContext& ctx) {
-	LOG_TRACE(ctx.logger) << log_func << LOG_ASYNC;
+	LOG_TRACE(ctx.logger, log_func);
 
 	protocol::cmsg_char_delete packet;
 
@@ -149,7 +149,7 @@ void character_delete(ClientContext& ctx) {
 }
 
 void player_login(ClientContext& ctx) {
-	LOG_TRACE(ctx.logger) << log_func << LOG_ASYNC;
+	LOG_TRACE(ctx.logger, log_func);
 
 	protocol::cmsg_player_login packet;
 

--- a/src/realm/states/WorldEnter.cpp
+++ b/src/realm/states/WorldEnter.cpp
@@ -266,7 +266,7 @@ void handle_join_channel(ClientContext& ctx) {
 	response->name = packet->name;
 	ctx.connection->send(response);
 
-	LOG_DEBUG_ASYNC(ctx.logger, "{}", response->name);
+	LOG_DEBUG(ctx.logger, "{}", response->name);
 }
 
 void handle_tutorial_flag(ClientContext& ctx) {
@@ -284,7 +284,7 @@ void handle_messagechat(ClientContext& ctx) {
 		return;
 	}
 
-	LOG_DEBUG_ASYNC(ctx.logger, "{}: {}", packet->destination, packet->message);
+	LOG_DEBUG(ctx.logger, "{}: {}", packet->destination, packet->message);
 
 	protocol::smsg_messagechat response;
 	response->type = (decltype(response->type))packet->type; // kek

--- a/src/social/MonitorCallbacks.cpp
+++ b/src/social/MonitorCallbacks.cpp
@@ -21,19 +21,19 @@ void monitor_log_callback(const Monitor::Source& source, Monitor::Severity sever
 
 	switch(severity) {
 		case Monitor::Severity::fatal:
-			LOG_FATAL(logger) << message << LOG_ASYNC;
+			LOG_FATAL(logger, message);
 			break;
 		case Monitor::Severity::error:
-			LOG_ERROR(logger) << message << LOG_ASYNC;
+			LOG_ERROR(logger, message);
 			break;
 		case Monitor::Severity::warn:
-			LOG_WARN(logger) << message << LOG_ASYNC;
+			LOG_WARN(logger, message);
 			break;
 		case Monitor::Severity::info:
-			LOG_INFO(logger) << message << LOG_ASYNC;
+			LOG_INFO(logger, message);
 			break;
 		case Monitor::Severity::debug:
-			LOG_DEBUG(logger) << message << LOG_ASYNC;
+			LOG_DEBUG(logger, message);
 			break;
 	}
 }

--- a/src/social/main.cpp
+++ b/src/social/main.cpp
@@ -56,11 +56,11 @@ int main(int argc, const char* argv[]) try {
 	log::Logger logger;
 	utility::configure_logger(logger, args);
 	log::global_logger(logger);
-	LOG_INFO(logger) << "Logger configured successfully" << LOG_SYNC;
+	SLOG_INFO(logger, "Logger configured successfully");
 
 	print_lib_versions(logger);
 	const auto ret = launch(args, logger);
-	LOG_INFO(logger) << "Social daemon terminated" << LOG_SYNC;
+	SLOG_INFO(logger, "Social daemon terminated");
 	return ret;
 } catch(const std::exception& e) {
 	std::cerr << e.what();
@@ -74,7 +74,8 @@ int launch(const opts::variables_map& args, log::Logger& logger) try {
 	auto metrics = std::make_unique<ember::Metrics>();
 
 	if(args["metrics.enabled"].as<bool>()) {
-		LOG_INFO(logger) << "Starting metrics service..." << LOG_SYNC;
+		SLOG_INFO(logger, "Starting metrics service...");
+
 		metrics = std::make_unique<ember::MetricsImpl>(
 			ioc, args["metrics.statsd_host"].as<std::string>(),
 			args["metrics.statsd_port"].as<std::uint16_t>()
@@ -85,7 +86,7 @@ int launch(const opts::variables_map& args, log::Logger& logger) try {
 	std::unique_ptr<ember::Monitor> monitor;
 
 	if(args["monitor.enabled"].as<bool>()) {
-		LOG_INFO(logger) << "Starting monitoring service..." << LOG_SYNC;
+		SLOG_INFO(logger, "Starting monitoring service...");
 
 		monitor = std::make_unique<ember::Monitor>(
 			ioc, args["monitor.interface"].as<std::string>(),
@@ -94,12 +95,12 @@ int launch(const opts::variables_map& args, log::Logger& logger) try {
 	}
 
 	boost::asio::dispatch(ioc, [&]() {
-		LOG_INFO(logger) << "Social daemon started successfully" << LOG_SYNC;
+		SLOG_INFO(logger, "Social daemon started successfully");
 	});
 
 	return EXIT_SUCCESS;
 } catch(const std::exception& e) {
-	LOG_FATAL_SYNC(logger, e.what());
+	SLOG_FATAL(logger, e.what());
 	return EXIT_FAILURE;
 }
 
@@ -177,7 +178,7 @@ opts::variables_map parse_arguments(const int argc, const char* argv[]) {
 
 
 void print_lib_versions(log::Logger& logger) {
-	LOG_DEBUG(logger)
+	LOG_DEBUG_STREAM(logger)
 		<< "Compiled with library versions: " << "\n"
 		<< " - Boost " << BOOST_VERSION / 100000 << "."
 		<< BOOST_VERSION / 100 % 1000 << "."

--- a/src/tools/dbutils/main.cpp
+++ b/src/tools/dbutils/main.cpp
@@ -115,11 +115,11 @@ int launch(const opts::variables_map& args, log::Logger& logger) try {
 	validate_options(args, logger);
 
 	if(!args["install"].empty()) {
-		LOG_INFO_SYNC(logger, "Starting database setup process...");
+		SLOG_INFO(logger, "Starting database setup process...");
 		const auto clean = args["clean"].as<bool>();
 
 		if(clean && !args["shutup"].as<bool>()) {
-			LOG_WARN_SYNC(logger, "You are performing an installation with --clean.\n"
+			SLOG_WARN(logger, "You are performing an installation with --clean.\n"
 			                      "This will drop any existing databases and users specified in the arguments!\n"
 			                      "Proceeding in {} seconds...", update_backout_period.count());
 			std::this_thread::sleep_for(update_backout_period);
@@ -135,11 +135,11 @@ int launch(const opts::variables_map& args, log::Logger& logger) try {
 				throw std::runtime_error("Unable to obtain a database executor. Invalid database type?");
 			}
 
-			LOG_INFO_SYNC(logger, "Testing connection {} @ {}:{} for {}",
+			SLOG_INFO(logger, "Testing connection {} @ {}:{} for {}",
 			              details.username, details.hostname, details.port, db);
 
 			if(executor->test_connection()) {
-				LOG_INFO_SYNC(logger, "Successfully established connection");
+				SLOG_INFO(logger, "Successfully established connection");
 			} else {
 				throw std::runtime_error("Unable to establish database connection");
 			}
@@ -149,23 +149,25 @@ int launch(const opts::variables_map& args, log::Logger& logger) try {
 			db_install(args, db, clean, logger);
 		}
 
-		LOG_INFO_SYNC(logger, "Database installation complete!");
+		SLOG_INFO(logger, "Database installation complete!");
 
 		if(args["update"].empty()) {
-			LOG_INFO_SYNC(logger, "Consider running --update.");
+			SLOG_INFO(logger, "Consider running --update.");
 		}
 	}
 
 	bool success = true;
 
 	if(!args["update"].empty()) {
-		LOG_INFO_SYNC(logger, "Starting database update process...");
+		SLOG_INFO(logger, "Starting database update process...");
 
 		if(!args["shutup"].as<bool>()) {
-			LOG_WARN(logger) << "Please ensure all running Ember services have been "
-			                    "stopped and you have backed up your database!\n"
-			                    "Proceeding in " << update_backout_period.count()
-			                 << " seconds..." << LOG_SYNC;
+			LOG_WARN_STREAM(logger)
+				<< "Please ensure all running Ember services have been "
+			        "stopped and you have backed up your database!\n"
+			        "Proceeding in " << update_backout_period.count()
+			    << " seconds..." << LOG_SYNC;
+
 			std::this_thread::sleep_for(update_backout_period);
 		}
 
@@ -177,19 +179,19 @@ int launch(const opts::variables_map& args, log::Logger& logger) try {
 	}
 
 	if(success) {
-		LOG_INFO_SYNC(logger, "All operations have completed successfully!");
+		SLOG_INFO(logger, "All operations have completed successfully!");
 	} else {
-		LOG_WARN_SYNC(logger, "Some operations did not complete successfully!");
+		SLOG_WARN(logger, "Some operations did not complete successfully!");
 	}
 
 	return success? EXIT_SUCCESS : EXIT_FAILURE;
 } catch(const std::exception& e) {
-	LOG_FATAL_SYNC(logger, "{}", e.what());
+	SLOG_FATAL(logger, "{}", e.what());
 	return EXIT_FAILURE;
 }
 
 void validate_options(const opts::variables_map& args, log::Logger& logger) {
-	LOG_TRACE(logger) << log_func << LOG_SYNC;
+	SLOG_TRACE(logger, log_func);
 
 	if(args["install"].empty() && args["update"].empty()) {
 		throw std::invalid_argument("At least --install or --update must be specified!");
@@ -215,14 +217,14 @@ bool validate_db_names(std::span<const std::string> input_names, log::Logger& lo
 	std::ranges::set_difference(input, valid_names, std::back_inserter(bad_names));
 	
 	for(const auto& name : bad_names) {
-		LOG_INFO_SYNC(logger, "Invalid or duplicate name: {}", name);
+		SLOG_INFO(logger, "Invalid or duplicate name: {}", name);
 	}
 
 	return bad_names.empty();
 }
 
 void validate_db_args(const opts::variables_map& po_args, const std::string& mode, log::Logger& logger) {
-	LOG_TRACE(logger) << log_func << LOG_SYNC;
+	SLOG_TRACE(logger, log_func);
 
 	const auto& dbs = po_args[mode].as<std::vector<std::string>>();
 
@@ -247,7 +249,7 @@ void validate_db_args(const opts::variables_map& po_args, const std::string& mod
 }
 
 std::vector<std::string> load_queries(const std::string& path, log::Logger& logger) {
-	LOG_TRACE(logger) << log_func << LOG_SYNC;
+	SLOG_TRACE(logger, log_func);
 
 	std::vector<std::string> queries;
 	std::fstream file(path, std::ios::in);
@@ -285,7 +287,7 @@ DatabaseDetails db_details(const opts::variables_map& args, const std::string& d
 }
 
 void db_install(const opts::variables_map& args, const std::string& db, const bool drop, log::Logger& logger) {
-	LOG_TRACE(logger) << log_func << LOG_SYNC;
+	SLOG_TRACE(logger, log_func);
 	const auto& sql_dir = args["sql-dir"].as<std::string>();
 	const auto& dbs = args["install"].as<std::vector<std::string>>();
 
@@ -322,11 +324,11 @@ void db_install(const opts::variables_map& args, const std::string& db, const bo
 		throw std::runtime_error("Privileged DB user and new user cannot match.");
 	}
 
-	LOG_INFO_SYNC(logger, "Creating database {}...", args[db_arg].as<std::string>());
+	SLOG_INFO(logger, "Creating database {}...", args[db_arg].as<std::string>());
 	executor->create_database(db_name, drop);
 	executor->select_db(db_name);
 
-	LOG_INFO_SYNC(logger, "Installing {} schema...", db_name);
+	SLOG_INFO(logger, "Installing {} schema...", db_name);
 	const auto& db_type = args["database-type"].as<std::string>();
 	const auto& path = args["sql-dir"].as<std::string>()  + db_type + "/" + db + "/schema.sql";
 	const auto& queries = load_queries(path, logger);
@@ -335,19 +337,20 @@ void db_install(const opts::variables_map& args, const std::string& db, const bo
 		executor->execute(query);
 	}
 
-	LOG_INFO_SYNC(logger, "Creating user {}...", user);
+	SLOG_INFO(logger, "Creating user {}...", user);
 	executor->create_user(user, pass, drop);
 
-	LOG_INFO_SYNC(logger, "Granting {}  access to {}...", user, db_name);
+	SLOG_INFO(logger, "Granting {}  access to {}...", user, db_name);
 	const bool read_only = (db == "world");
 	executor->grant_user(user, db_name, read_only);
-	LOG_INFO_SYNC(logger, "Successfully installed {}", db);
+	SLOG_INFO(logger, "Successfully installed {}", db);
 }
 
 bool apply_updates(const opts::variables_map& args, QueryExecutor& exec,
                    std::span<std::string> migration_paths, const std::string& db,
                    log::Logger& logger) {
-	LOG_TRACE(logger) << log_func << LOG_SYNC;
+	SLOG_TRACE(logger, log_func);
+
 	const auto transactions = args["transactional-updates"].as<bool>();
 	const auto batched = args["single-transaction"].as<bool>();
 	exec.select_db(db);
@@ -358,7 +361,7 @@ bool apply_updates(const opts::variables_map& args, QueryExecutor& exec,
 
 	for(const auto& path : migration_paths) {
 		try {
-			LOG_INFO_SYNC(logger, "Applying {}", path);
+			SLOG_INFO(logger, "Applying {}", path);
 			const auto& queries = load_queries(path, logger);
 
 			if(transactions && !batched) {
@@ -388,13 +391,13 @@ bool apply_updates(const opts::variables_map& args, QueryExecutor& exec,
 				exec.end_transaction();
 			}
 		} catch(const std::exception& e) {
-			LOG_ERROR_SYNC(logger, "{}: {}", path, e.what());
+			SLOG_ERROR(logger, "{}: {}", path, e.what());
 
 			if (transactions || batched) {
-				LOG_ERROR_SYNC(logger, "Migration failed, attempting rollback...");
+				SLOG_ERROR(logger, "Migration failed, attempting rollback...");
 				exec.rollback();
 			} else {
-				LOG_ERROR_SYNC(logger, "Migration failed, you may need to restore your database.");
+				SLOG_ERROR(logger, "Migration failed, you may need to restore your database.");
 			}
 
 			return false;
@@ -409,8 +412,8 @@ bool apply_updates(const opts::variables_map& args, QueryExecutor& exec,
 }
 
 bool db_update(const opts::variables_map& args, const std::string& db, log::Logger& logger) {
-	LOG_TRACE(logger) << log_func << LOG_SYNC;
-	LOG_INFO_SYNC(logger, "Applying updates for {}...", db);
+	SLOG_TRACE(logger, log_func);
+	SLOG_INFO(logger, "Applying updates for {}...", db);
 
 	const auto& details = db_details(args, db);			
 	auto executor = db_executor(args["database-type"].as<std::string>(), details);
@@ -450,7 +453,7 @@ bool db_update(const opts::variables_map& args, const std::string& db, log::Logg
 	for(const auto& path : paths) {
 		// filter out any migrations older than the last applied migration
 		if(!applied_migrations.empty() && path.filename() <= applied_migrations.back().file) {
-			LOG_DEBUG_SYNC(logger, "Skipping {}", path.string());
+			SLOG_DEBUG(logger, "Skipping {}", path.string());
 			continue;
 		}
 
@@ -459,29 +462,29 @@ bool db_update(const opts::variables_map& args, const std::string& db, log::Logg
 
 	const auto applied_sz = applied_migrations.size();
 	const auto paths_sz = migration_paths.size();
-	LOG_INFO_SYNC(logger, "Database has {} migration{} applied", applied_sz, pluralise(applied_sz)? "s" : "");
-	LOG_INFO_SYNC(logger, "Found {} applicable migration{}", paths_sz, pluralise(paths_sz)? "s" : "");
+	SLOG_INFO(logger, "Database has {} migration{} applied", applied_sz, pluralise(applied_sz)? "s" : "");
+	SLOG_INFO(logger, "Found {} applicable migration{}", paths_sz, pluralise(paths_sz)? "s" : "");
 
 	if(!applied_migrations.empty()) {
 		const auto& last = applied_migrations.back();
-		LOG_INFO_SYNC(logger, "Current migration: {}", last.file);
+		SLOG_INFO(logger, "Current migration: {}", last.file);
 	}
 
 	if(migration_paths.empty() && applied_migrations.empty()) {
-		LOG_WARN_SYNC(logger, "The database has no migration history and no applicable migrations were found. "
+		SLOG_WARN(logger, "The database has no migration history and no applicable migrations were found. "
 		                      "No updates applied!");
 		return true;
 	} else if(migration_paths.empty()) {
-		LOG_INFO_SYNC(logger, "Database appears to already be up to date!");
+		SLOG_INFO(logger, "Database appears to already be up to date!");
 		return true;
 	}
 
 	const auto res = apply_updates(args, *executor, migration_paths, db_name, logger);
 
 	if(res) {
-		LOG_INFO_SYNC(logger, "Database migrations applied successfully.");
+		SLOG_INFO(logger, "Database migrations applied successfully.");
 	} else {
-		LOG_WARN_SYNC(logger, "Some migrations could not be applied.");
+		SLOG_WARN(logger, "Some migrations could not be applied.");
 	}
 
 	return res;

--- a/src/world/MapRunner.cpp
+++ b/src/world/MapRunner.cpp
@@ -39,7 +39,7 @@ void update(std::chrono::milliseconds delta) {
  * system time (e.g. DST) to impact the game logic.
  */
 void run(log::Logger& log, bool& stop_flag) {
-	LOG_TRACE(log) << log_func << LOG_ASYNC;
+	LOG_TRACE(log, log_func);
 
 	const utility::ScopedTimerPeriod timer_guard(TIME_PERIOD);
 
@@ -51,7 +51,7 @@ void run(log::Logger& log, bool& stop_flag) {
 	 */
 	if(!timer_guard.success()) {
 		const auto src = std::source_location::current();
-		LOG_ERROR_ASYNC(log, "{}:{} - failed to set time period", src.file_name(), src.line());
+		LOG_ERROR(log, "{}:{} - failed to set time period", src.file_name(), src.line());
 	}
 
 	Watchdog watchdog(WATCHDOG_PERIOD, log);

--- a/src/world/Service.cpp
+++ b/src/world/Service.cpp
@@ -35,21 +35,21 @@ int Service::run(const boost::program_options::variables_map& args) {
 	const auto time = std::chrono::steady_clock::now();
 	auto ctx = context.get();
 
-	LOG_INFO_SYNC(logger, "Loading DBC data...");
+	SLOG_INFO(logger, "Loading DBC data...");
 
 	dbc::DiskLoader loader(args["dbc.path"].as<std::string>(), [&](auto message) {
-		LOG_DEBUG(logger) << message << LOG_SYNC;
+		SLOG_DEBUG(logger, message);
 	});
 
 	ctx->dbcs = std::make_unique<dbc::Storage>(std::move(loader.load(dbcs_required)));
 
-	LOG_INFO_SYNC(logger, "Resolving DBC references...");
+	SLOG_INFO(logger, "Resolving DBC references...");
 	dbc::link(*ctx->dbcs);
 
 	const auto tip = random_tip(ctx->dbcs->game_tips);
 
 	if(!tip.empty()) {
-		LOG_INFO_SYNC(logger, "Tip: {}", tip);
+		SLOG_INFO(logger, "Tip: {}", tip);
 	}
 
 	const auto& maps = args["world.map_id"].as<std::vector<std::int32_t>>();
@@ -58,7 +58,7 @@ int Service::run(const boost::program_options::variables_map& args) {
 		return EXIT_FAILURE;
 	}
 
-	LOG_INFO_SYNC(logger, "Serving as world server for maps:");
+	SLOG_INFO(logger, "Serving as world server for maps:");
 	print_maps(maps, ctx->dbcs->map, logger);
 
 	// temporary bits
@@ -72,14 +72,14 @@ int Service::run(const boost::program_options::variables_map& args) {
 	// end of temporary bits
 
 	// All done setting up
-	LOG_INFO_SYNC(logger, "{} started successfully in {}", app_name, utility::time_elapsed_format(time));
+	SLOG_INFO(logger, "{} started successfully in {}", app_name, utility::time_elapsed_format(time));
 	start_time = time;
 
 	map::run(logger, stop_flag);
 
 	// temp bits again
 	ctx->spark->shutdown();
-	LOG_INFO_SYNC(logger, "{} terminated", app_name);
+	SLOG_INFO(logger, "{} terminated", app_name);
 	return EXIT_SUCCESS;
 }
 

--- a/src/world/Watchdog.cpp
+++ b/src/world/Watchdog.cpp
@@ -34,7 +34,7 @@ Watchdog::Watchdog(std::chrono::seconds max_idle, log::Logger& logger)
 }
 
 void Watchdog::run(const std::stop_token token) {
-	LOG_DEBUG_ASYNC(logger_, "Watchdog active ({} frequency)", max_idle_);
+	LOG_DEBUG(logger_, "Watchdog active ({} frequency)", max_idle_);
 
 	std::mutex mutex;
 	auto cond_var = std::condition_variable_any();
@@ -51,7 +51,7 @@ void Watchdog::run(const std::stop_token token) {
 		}
 	}
 
-	LOG_DEBUG_ASYNC(logger_, "Watchdog stopped");
+	LOG_DEBUG(logger_, "Watchdog stopped");
 }
 
 bool Watchdog::check_timeout() {
@@ -68,7 +68,7 @@ bool Watchdog::check_timeout() {
 }
 
 void Watchdog::terminate() const {
-	LOG_FATAL_SYNC(logger_, "Watchdog triggered after {}, terminating...",
+	SLOG_FATAL(logger_, "Watchdog triggered after {}, terminating...",
 	               std::chrono::duration_cast<std::chrono::seconds>(delta_));
 	std::abort();
 }

--- a/src/world/WorldRPCServer.cpp
+++ b/src/world/WorldRPCServer.cpp
@@ -20,11 +20,11 @@ WorldRPCServer::WorldRPCServer(spark::Server& spark, log::Logger& logger)
 }
 
 void WorldRPCServer::on_link_up(const spark::Link& link) {
-	LOG_DEBUG_ASYNC(logger_, "Link up: {}", link.peer_banner);
+	LOG_DEBUG(logger_, "Link up: {}", link.peer_banner);
 }
 
 void WorldRPCServer::on_link_down(const spark::Link& link) {
-	LOG_DEBUG_ASYNC(logger_, "Link down: {}", link.peer_banner);
+	LOG_DEBUG(logger_, "Link down: {}", link.peer_banner);
 }
 
 std::optional<StatusT>

--- a/src/world/main.cpp
+++ b/src/world/main.cpp
@@ -47,16 +47,16 @@ int main(int argc, const char* argv[]) try {
 	log::Logger logger;
 	utility::configure_logger(logger, args);
 	log::global_logger(logger);
-	LOG_INFO_SYNC(logger, "Logger configured successfully");
+	SLOG_INFO(logger, "Logger configured successfully");
 
-	LOG_DEBUG_SYNC(logger, "Registering command handlers...");
+	SLOG_DEBUG(logger, "Registering command handlers...");
 	const auto suggestions = args["console_log.suggestions"].as<bool>();
 	commands::Registry registry;
 	utility::register_command_handlers(registry, logger, suggestions);
 	utility::register_shared_commands(registry, logger);
 
 	const auto ret = run(args, logger, registry);
-	LOG_INFO_SYNC(logger, "{} terminated (returned '{}')", world::app_name, ret);
+	SLOG_INFO(logger, "{} terminated (returned '{}')", world::app_name, ret);
 	return ret;
 } catch(const std::exception& e) {
 	std::cerr << e.what();
@@ -74,7 +74,7 @@ int run(const opts::variables_map& args, log::Logger& logger, commands::Registry
 			return;
 		}
 
-		LOG_DEBUG_SYNC(logger, "Received signal {}({})", utility::sig_str(signal), signal);
+		SLOG_DEBUG(logger, "Received signal {}({})", utility::sig_str(signal), signal);
 		signals.clear();
 		service.stop();
 	});
@@ -88,7 +88,7 @@ int run(const opts::variables_map& args, log::Logger& logger, commands::Registry
 	signals.cancel();
 	return ret;
 } catch(const std::exception& e) {
-	LOG_FATAL(logger) << e.what() << LOG_SYNC;
+	SLOG_FATAL(logger, e.what());
 	return EXIT_FAILURE;
 }
 

--- a/src/world/utilities/Utility.cpp
+++ b/src/world/utilities/Utility.cpp
@@ -49,14 +49,14 @@ bool validate_maps(std::span<const std::int32_t> maps, const dbc::Store<dbc::Map
 		});
 
 		if(it == dbc.end()) {
-			LOG_ERROR_SYNC(logger, "Unknown map ID ({}) specified", id);
+			SLOG_ERROR(logger, "Unknown map ID ({}) specified", id);
 			return false;
 		}
 
 		auto& [_, map] = *it;
 
 		if(map.instance_type != dbc::Map::InstanceType::NORMAL) {
-			LOG_ERROR_SYNC(logger, "Map {} ({}) is not an open world area", map.id, map.map_name.en_gb);
+			SLOG_ERROR(logger, "Map {} ({}) is not an open world area", map.id, map.map_name.en_gb);
 			return false;
 		}
 
@@ -68,7 +68,7 @@ bool validate_maps(std::span<const std::int32_t> maps, const dbc::Store<dbc::Map
 
 void print_maps(std::span<const std::int32_t> maps, const dbc::Store<dbc::Map>& dbc, log::Logger& logger) {
 	for(auto id : maps) {
-		LOG_INFO_SYNC(logger, " - {}", dbc[id]->map_name.en_gb);
+		SLOG_INFO(logger, " - {}", dbc[id]->map_name.en_gb);
 	}
 }
 


### PR DESCRIPTION
No longer requires *_ASYNC to be explicitly specified. _SYNC is now called by using SLOG rather than LOG. Old API is now prefixed as *_STREAM.