### PR TITLE
Add locked session iterator to allow safe client iteration outside of the session manager

### DIFF
--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -65,6 +65,7 @@ set(LIBRARY_HDR
     BroadcastTimer.h
     Forwards.h
     ClientTimer.h
+    SessionIterator.h
 )
 
 set(LIBRARY_SRC
@@ -115,7 +116,7 @@ if(BUILD_SHARED)
 endif()
 
 if(ENABLE_FAST_CLIENT_DISPATCH_CACHE)
-	target_compile_definitions(${LIBRARY_NAME} PUBLIC EMBER_FAST_DISPATCH_CACHE)
+    target_compile_definitions(${LIBRARY_NAME} PUBLIC EMBER_FAST_DISPATCH_CACHE)
 endif()
 
 target_compile_definitions(${LIBRARY_NAME} PRIVATE PREALLOCATED_CLIENTS_PER_THREAD=${PREALLOC_CLIENTS_THREAD})

--- a/src/realm/QoS.cpp
+++ b/src/realm/QoS.cpp
@@ -23,18 +23,18 @@ void QoS::set_timer() {
 }
 
 void QoS::measure_bandwidth() {
-	auto stats = sessions_.aggregate_stats();
-	auto timer_ms = std::chrono::duration_cast<std::chrono::milliseconds>(TIMER_FREQUENCY);
-	auto seconds = timer_ms.count() / 1000.0;
+	//auto stats = 0;
+	//auto timer_ms = std::chrono::duration_cast<std::chrono::milliseconds>(TIMER_FREQUENCY);
+	//auto seconds = timer_ms.count() / 1000.0;
 
-	auto out_per_sec = (stats.bytes_out - last_bandwidth_out_) / seconds;
-	auto target_bandwidth = (config_.max_bandwidth_out / 100.0) * MAX_BANDWIDTH_PERCENTAGE;
+	//auto out_per_sec = (stats.bytes_out - last_bandwidth_out_) / seconds;
+	//auto target_bandwidth = (config_.max_bandwidth_out / 100.0) * MAX_BANDWIDTH_PERCENTAGE;
 
-	if(out_per_sec > target_bandwidth) {
-		// bump up the compression level
-	}
+	//if(out_per_sec > target_bandwidth) {
+	//	// bump up the compression level
+	//}
 
-	last_bandwidth_out_ = stats.bytes_out;
+	//last_bandwidth_out_ = stats.bytes_out;
 }
 
 void QoS::shutdown() {

--- a/src/realm/SessionIterator.h
+++ b/src/realm/SessionIterator.h
@@ -15,18 +15,15 @@ namespace ember::realm {
 
 template<typename _iter_type>
 class SessionIterator {
+	std::unique_lock<std::mutex> lock_;
+	_iter_type it_;
+
 public:
 	using iterator_category = std::forward_iterator_tag;
 	using difference_type   = std::ptrdiff_t;
 	using value_type        = typename _iter_type::value_type;
 	using pointer           = typename _iter_type::pointer;
 	using reference         = typename _iter_type::reference;
-
-public:
-	friend class SessionContainer;
-
-	std::unique_lock<std::mutex> lock_;
-	_iter_type it_;
 
 	SessionIterator(_iter_type it, std::mutex& m)
 		: lock_(m)
@@ -35,7 +32,6 @@ public:
 	SessionIterator(_iter_type it)
 		: it_(it) {}
 
-public:
 	SessionIterator(const SessionIterator&) = delete;
 	SessionIterator& operator=(const SessionIterator&) = delete;
 

--- a/src/realm/SessionIterator.h
+++ b/src/realm/SessionIterator.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Ember
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <iterator>
+#include <mutex>
+
+namespace ember::realm {
+
+template<typename _iter_type>
+class SessionIterator {
+public:
+	using iterator_category = std::forward_iterator_tag;
+	using difference_type   = std::ptrdiff_t;
+	using value_type        = typename _iter_type::value_type;
+	using pointer           = typename _iter_type::pointer;
+	using reference         = typename _iter_type::reference;
+
+public:
+	friend class SessionContainer;
+
+	std::unique_lock<std::mutex> lock_;
+	_iter_type it_;
+
+	SessionIterator(_iter_type it, std::mutex& m)
+		: lock_(m)
+		, it_(it) {}
+
+	SessionIterator(_iter_type it)
+		: it_(it) {}
+
+public:
+	SessionIterator(const SessionIterator&) = delete;
+	SessionIterator& operator=(const SessionIterator&) = delete;
+
+	SessionIterator(SessionIterator&&) = default;
+	SessionIterator& operator=(SessionIterator&&) = default;
+
+	reference operator*() {
+		return *it_;
+	}
+
+	reference operator->() {
+		return it_->second;
+	}
+
+	SessionIterator& operator++() {
+		++it_;
+		return *this; 
+	}
+
+	bool operator!=(const SessionIterator& other) const {
+		return it_ != other.it_; 
+	}
+
+	bool operator==(const SessionIterator& other) const {
+		return it_ == other.it_; 
+	}
+};
+
+} // realm, ember

--- a/src/realm/SessionManager.cpp
+++ b/src/realm/SessionManager.cpp
@@ -47,24 +47,20 @@ std::size_t SessionManager::count() const {
 	return sessions_.size();
 }
 
-ConnectionStats SessionManager::aggregate_stats() const {
-	std::lock_guard guard(sessions_lock_);
+auto SessionManager::begin() -> locked_iterator {
+	return SessionIterator(sessions_.begin(), sessions_lock_);
+}
 
-	ConnectionStats ag_stats {};
+auto SessionManager::end() -> locked_iterator {
+	return SessionIterator(sessions_.end());
+}
 
-	for(const auto& session : sessions_) {
-		const auto& stats = session->connection().stats();
-		ag_stats.bytes_in += stats.bytes_in;
-		ag_stats.bytes_out += stats.bytes_out;
-		ag_stats.latency += stats.latency;
-		ag_stats.messages_in += stats.messages_in;
-		ag_stats.messages_out += stats.messages_out;
-		ag_stats.async_receives += stats.async_receives;
-		ag_stats.async_sends += stats.async_sends;
-	}
+auto SessionManager::begin() const -> locked_const_iterator {
+	return SessionIterator(sessions_.begin(), sessions_lock_);
+}
 
-	ag_stats.latency /= count(); // average latency
-	return ag_stats;
+auto SessionManager::end() const -> locked_const_iterator {
+	return SessionIterator(sessions_.end());
 }
 
 SessionManager::~SessionManager() {

--- a/src/realm/SessionManager.h
+++ b/src/realm/SessionManager.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Client.h"
+#include "SessionIterator.h"
 #include <spark/buffers/allocators/TLSBlockAllocator.h>
 #include <boost/unordered/unordered_flat_set.hpp>
 #include <memory>
@@ -50,10 +51,15 @@ class SessionManager final {
 		}
 	};
 
-	boost::unordered_flat_set<ClientPtr, Hasher, KeyEqual> sessions_;
+	using SessionsMap = boost::unordered_flat_set<ClientPtr, Hasher, KeyEqual>;
+
+	SessionsMap sessions_;
 	mutable std::mutex sessions_lock_;
 
 public:
+	using locked_iterator = SessionIterator<SessionsMap::iterator>;
+	using locked_const_iterator = SessionIterator<SessionsMap::const_iterator>;
+
 	SessionManager() = default;
 	~SessionManager();
 
@@ -61,7 +67,11 @@ public:
 	void stop(Client* session);
 	void stop_all();
 	std::size_t count() const;
-	ConnectionStats aggregate_stats() const;
+
+	locked_iterator begin();
+	locked_iterator end();
+	locked_const_iterator begin() const;
+	locked_const_iterator end() const;
 };
 
 } // realm, ember


### PR DESCRIPTION
Could put this in 'shared' but it'll do for now. Not using a shared mutex due to the performance overhead when this will likely only be used by infrequent commands.