### PR TITLE
Tidy up client event handling

### DIFF
--- a/src/realm/ClientHandler.cpp
+++ b/src/realm/ClientHandler.cpp
@@ -57,10 +57,10 @@ void ClientHandler::handle_message(StaticBuffer& buffer, const protocol::SizeTyp
 	update_packet[context_.state](context_, opcode);
 }
 
-bool ClientHandler::handle_self_event(const Event* event) {
+bool ClientHandler::handle_self_event(const Event& event) {
 	using enum EventType;
 
-	switch(event->type) {
+	switch(event.type) {
 		case interval_timer_fire:
 			handle_timer();
 			return true;
@@ -78,20 +78,12 @@ bool ClientHandler::handle_self_event(const Event* event) {
 	}
 }
 
-void ClientHandler::handle_event(const Event* event) {
+void ClientHandler::handle_event(const Event& event) {
 	if(handle_self_event(event)) {
 		return;
 	}
 
 	update_event[context_.state](context_, event);
-}
-
-void ClientHandler::handle_event(std::unique_ptr<const Event> event) {
-	if(handle_self_event(event.get())) {
-		return;
-	}
-
-	update_event[context_.state](context_, event.get());
 }
 
 void ClientHandler::handle_timer() {

--- a/src/realm/ClientHandler.h
+++ b/src/realm/ClientHandler.h
@@ -65,7 +65,7 @@ class ClientHandler final {
 	void handle_ping(BinaryStream& stream);
 	void handle_timer();
 	bool pps_flood_check();
-	bool handle_self_event(const Event* event);
+	bool handle_self_event(const Event& event);
 	void packet_log_start();
 
 	void start_timer(const std::chrono::milliseconds& time);
@@ -98,8 +98,7 @@ public:
 
 	void state_update(ClientState new_state);
 	void handle_message(StaticBuffer& buffer, protocol::SizeType msg_size);
-	void handle_event(const Event* event);
-	void handle_event(std::unique_ptr<const Event> event);
+	void handle_event(const Event& event);
 
 	void log_redirect(LogRedirect::Type type, log::Severity severity);
 	void log_redirect_stop();

--- a/src/realm/EventDispatcher.cpp
+++ b/src/realm/EventDispatcher.cpp
@@ -27,7 +27,7 @@ void EventDispatcher::post_event(const ClientIdent& client, std::unique_ptr<Even
 
 	boost::asio::post(*service, [&, client, event = std::move(event)] {
 		if(auto handler = locate_handler(client)) {
-			handler->handle_event(event.get());
+			handler->handle_event(*event);
 		} else {
 			LOG_DEBUG(logger_, "Client disconnected, event discarded");
 		}
@@ -72,7 +72,7 @@ void EventDispatcher::broadcast_event(std::vector<ClientIdent> clients, std::sha
 
 			while(beg != end) {
 				if(auto handler = locate_handler(*beg++)) {
-					handler->handle_event(event.get());
+					handler->handle_event(*event);
 				} else {
 					LOG_DEBUG(logger_, "Client disconnected, event discarded");
 				}
@@ -83,13 +83,13 @@ void EventDispatcher::broadcast_event(std::vector<ClientIdent> clients, std::sha
 
 void EventDispatcher::broadcast(const Event& event) const {
 	for(auto& handler : handlers_ | std::views::values) {
-		handler->handle_event(&event);
+		handler->handle_event(event);
 	}
 
 #ifdef EMBER_FAST_DISPATCH_CACHE
 	for(auto& entry : cache_) {
 		if(!entry.is_zero()) {
-			entry.extract_ptr<ClientHandler>()->handle_event(&event);
+			entry.extract_ptr<ClientHandler>()->handle_event(event);
 		}
 	}
 #endif
@@ -110,7 +110,7 @@ void EventDispatcher::broadcast_event(std::shared_ptr<const Event> event) const 
 	for(auto& ioc : pool_.services()) {
 		boost::asio::dispatch(ioc, [event]() {
 			for(auto& handler : handlers_ | std::views::values) {
-				handler->handle_event(event.get());
+				handler->handle_event(*event);
 			}
 		});
 	}

--- a/src/realm/EventDispatcher.h
+++ b/src/realm/EventDispatcher.h
@@ -101,7 +101,7 @@ public:
 
 		boost::asio::post(*service, [&, client, event = std::move(event)] {
 			if(auto handler = locate_handler(client)) {
-				handler->handle_event(&event);
+				handler->handle_event(event);
 			} else {
 				LOG_DEBUG(logger_, "Client disconnected, event discarded");
 			}

--- a/src/realm/states/Authentication.cpp
+++ b/src/realm/states/Authentication.cpp
@@ -40,7 +40,7 @@ using AddonData = protocol::client::AuthSession::AddonData;
 void send_auth_challenge(ClientContext& ctx);
 void send_auth_result(ClientContext& ctx, protocol::Result result);
 void handle_authentication(ClientContext& ctx);
-void handle_queue_update(ClientContext& ctx, const QueuePosition* event);
+void handle_queue_update(ClientContext& ctx, const QueuePosition& event);
 void handle_queue_success(ClientContext& ctx);
 void auth_success(ClientContext& ctx);
 void auth_queue(ClientContext& ctx);
@@ -112,15 +112,15 @@ void fetch_account_id(const ClientContext& ctx, const utf8_string& username) {
 	});
 }
 
-void handle_account_id(ClientContext& ctx, const AccountIDResponse* event) {
+void handle_account_id(ClientContext& ctx, const AccountIDResponse& event) {
 	LOG_TRACE(ctx.logger, log_func);
 	
 	auto& auth_ctx = std::get<Context>(ctx.state_ctx);
 
-	if(event->status != rpc::Account::Status::ok) {
+	if(event.status != rpc::Account::Status::ok) {
 		CLIENT_ERROR(ctx.logger, ctx)
 			<< "Account server returned "
-			<< utility::fb_status(event->status, rpc::Account::EnumNamesStatus())
+			<< utility::fb_status(event.status, rpc::Account::EnumNamesStatus())
 			<< " for " << auth_ctx.packet->username << " lookup" << LOG_ASYNC;
 
 		auth_state(ctx, State::failed);
@@ -128,9 +128,9 @@ void handle_account_id(ClientContext& ctx, const AccountIDResponse* event) {
 		return;
 	}
 
-	if(event->account_id) {
-		auth_ctx.account_id = event->account_id;
-		fetch_session_key(ctx, event->account_id);
+	if(event.account_id) {
+		auth_ctx.account_id = event.account_id;
+		fetch_session_key(ctx, event.account_id);
 	} else {
 		CLIENT_DEBUG(ctx.logger, ctx)
 			<< "Account ID lookup for failed for "
@@ -152,16 +152,16 @@ void fetch_session_key(const ClientContext& ctx, const std::uint32_t account_id)
 	});
 }
 
-void handle_session_key(ClientContext& ctx, const SessionKeyResponse* event) {
+void handle_session_key(ClientContext& ctx, const SessionKeyResponse& event) {
 	const auto& auth_ctx = std::get<Context>(ctx.state_ctx);
 
 	CLIENT_DEBUG(ctx.logger, ctx)
 		<< "Account server returned "
-		<< utility::fb_status(event->status, rpc::Account::EnumNamesStatus())
+		<< utility::fb_status(event.status, rpc::Account::EnumNamesStatus())
 		<< " for " << auth_ctx.packet->username << LOG_ASYNC;
 
-	if(event->status == rpc::Account::Status::ok) {
-		prove_session(ctx, event->key);
+	if(event.status == rpc::Account::Status::ok) {
+		prove_session(ctx, event.key);
 	} else {
 		auth_state(ctx, State::failed);
 		ctx.handler.close();
@@ -296,12 +296,12 @@ void send_auth_result(ClientContext& ctx, protocol::Result result) {
 	ctx.handler.send(response);
 }
 
-void handle_queue_update(ClientContext& ctx, const QueuePosition* event) {
+void handle_queue_update(ClientContext& ctx, const QueuePosition& event) {
 	LOG_TRACE(ctx.logger, log_func);
 
 	protocol::smsg_auth_response packet;
 	packet->result = protocol::Result::auth_wait_queue;
-	packet->queue_position = gsl::narrow_cast<std::uint32_t>(event->position);
+	packet->queue_position = gsl::narrow_cast<std::uint32_t>(event.position);
 	ctx.handler.send(packet);
 }
 
@@ -334,21 +334,23 @@ void handle_packet(ClientContext& ctx, protocol::ClientOpcode opcode) {
 	}
 }
 
-void handle_event(ClientContext& ctx, const Event* event) {
-	switch(event->type) {
-		case EventType::timer_expired:
+void handle_event(ClientContext& ctx, const Event& event) {
+	using enum EventType;
+
+	switch(event.type) {
+		case timer_expired:
 			handle_timeout(ctx);
 			break;
-		case EventType::account_id_response:
-			handle_account_id(ctx, static_cast<const AccountIDResponse*>(event));
+		case account_id_response:
+			handle_account_id(ctx, static_cast<const AccountIDResponse&>(event));
 			break;
-		case EventType::session_key_response:
-			handle_session_key(ctx, static_cast<const SessionKeyResponse*>(event));
+		case session_key_response:
+			handle_session_key(ctx, static_cast<const SessionKeyResponse&>(event));
 			break;
-		case EventType::queue_update_position:
-			handle_queue_update(ctx, static_cast<const QueuePosition*>(event));
+		case queue_update_position:
+			handle_queue_update(ctx, static_cast<const QueuePosition&>(event));
 			break;
-		case EventType::queue_success:
+		case queue_success:
 			handle_queue_success(ctx);
 			break;
 		default:

--- a/src/realm/states/Authentication.h
+++ b/src/realm/states/Authentication.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 - 2025 Ember
+ * Copyright (c) 2016 - 2026 Ember
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -15,7 +15,7 @@ namespace ember::realm::authentication {
 
 void enter(ClientContext& ctx);
 void handle_packet(ClientContext& ctx, protocol::ClientOpcode opcode);
-void handle_event(ClientContext& ctx, const Event* event);
+void handle_event(ClientContext& ctx, const Event& event);
 void exit(ClientContext& ctx);
 
 } // authentication, realm, ember

--- a/src/realm/states/CharacterList.cpp
+++ b/src/realm/states/CharacterList.cpp
@@ -48,13 +48,13 @@ void send_character_list(ClientContext& ctx, std::vector<Character> characters) 
 	ctx.handler.send(response);
 }
 
-void send_character_rename(ClientContext& ctx, const CharRenameResponse* res) {
+void send_character_rename(ClientContext& ctx, const CharRenameResponse& res) {
 	LOG_TRACE(ctx.logger, log_func);
 
 	protocol::smsg_char_rename response;
-	response->result = res->result;
-	response->id = res->character_id;
-	response->name = res->name;
+	response->result = res.result;
+	response->id = res.character_id;
+	response->name = res.name;
 	ctx.handler.send(response);
 }
 
@@ -91,29 +91,29 @@ void character_enumerate(const ClientContext& ctx) {
 	);
 }
 
-void character_enumerate_completion(ClientContext& ctx, const CharEnumResponse* event) {
+void character_enumerate_completion(ClientContext& ctx, const CharEnumResponse& res) {
 	LOG_TRACE(ctx.logger, log_func);
 
-	if(event->status == rpc::Character::Status::ok) {
-		send_character_list(ctx, event->characters);
+	if(res.status == rpc::Character::Status::ok) {
+		send_character_list(ctx, res.characters);
 	} else {
 		send_character_list_fail(ctx);
 	}
 }
 
-void send_character_delete(ClientContext& ctx, const CharDeleteResponse* res) {
+void send_character_delete(ClientContext& ctx, const CharDeleteResponse& res) {
 	LOG_TRACE(ctx.logger, log_func);
 
 	protocol::smsg_char_delete response;
-	response->result = res->result;
+	response->result = res.result;
 	ctx.handler.send(response);
 }
 
-void send_character_create(ClientContext& ctx, const CharCreateResponse* res) {
+void send_character_create(ClientContext& ctx, const CharCreateResponse& res) {
 	LOG_TRACE(ctx.logger, log_func);
 
 	protocol::smsg_char_create response;
-	response->result = res->result;
+	response->result = res.result;
 	ctx.handler.send(response);
 }
 
@@ -202,22 +202,24 @@ void handle_packet(ClientContext& ctx, protocol::ClientOpcode opcode) {
 	}
 }
 
-void handle_event(ClientContext& ctx, const Event* event) {
-	switch(event->type) {
-		case EventType::timer_expired:
+void handle_event(ClientContext& ctx, const Event& event) {
+	using enum EventType;
+
+	switch(event.type) {
+		case timer_expired:
 			handle_timeout(ctx);
 			break;
-		case EventType::char_create_response:
-			send_character_create(ctx, static_cast<const CharCreateResponse*>(event));
+		case char_create_response:
+			send_character_create(ctx, static_cast<const CharCreateResponse&>(event));
 			break;
-		case EventType::char_delete_response:
-			send_character_delete(ctx, static_cast<const CharDeleteResponse*>(event));
+		case char_delete_response:
+			send_character_delete(ctx, static_cast<const CharDeleteResponse&>(event));
 			break;
-		case EventType::char_enum_response:
-			character_enumerate_completion(ctx, static_cast<const CharEnumResponse*>(event));
+		case char_enum_response:
+			character_enumerate_completion(ctx, static_cast<const CharEnumResponse&>(event));
 			break;
-		case EventType::char_rename_response:
-			send_character_rename(ctx, static_cast<const CharRenameResponse*>(event));
+		case char_rename_response:
+			send_character_rename(ctx, static_cast<const CharRenameResponse&>(event));
 			break;
 		default:
 			break;

--- a/src/realm/states/CharacterList.h
+++ b/src/realm/states/CharacterList.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 - 2025 Ember
+ * Copyright (c) 2016 - 2026 Ember
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -15,7 +15,7 @@ namespace ember::realm::character_list {
 
 void enter(ClientContext& ctx);
 void handle_packet(ClientContext& ctx, protocol::ClientOpcode opcode);
-void handle_event(ClientContext& ctx, const Event* event);
+void handle_event(ClientContext& ctx, const Event& event);
 void exit(ClientContext& ctx);
 
 } // character_list, realm, ember

--- a/src/realm/states/SessionClose.cpp
+++ b/src/realm/states/SessionClose.cpp
@@ -22,7 +22,7 @@ void handle_packet(ClientContext& ctx, protocol::ClientOpcode opcode) {
 	ctx.handler.skip(*ctx.stream);
 }
 
-void handle_event(ClientContext& ctx, const Event* event) {
+void handle_event(ClientContext& ctx, const Event& event) {
     // don't care, for now
 }
 

--- a/src/realm/states/SessionClose.h
+++ b/src/realm/states/SessionClose.h
@@ -15,7 +15,7 @@ namespace ember::realm::session_close {
 
 void enter(ClientContext& ctx);
 void handle_packet(ClientContext& ctx, protocol::ClientOpcode opcode);
-void handle_event(ClientContext& ctx, const Event* event);
+void handle_event(ClientContext& ctx, const Event& event);
 void exit(ClientContext& ctx);
 
 } // session_close, realm, ember

--- a/src/realm/states/StateJumpTables.h
+++ b/src/realm/states/StateJumpTables.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 - 2025 Ember
+ * Copyright (c) 2016 - 2026 Ember
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -29,7 +29,7 @@ struct ClientContext;
 struct Event;
 
 using state_func = void(*)(ClientContext&);
-using event_handler = void(*)(ClientContext&, const Event*);
+using event_handler = void(*)(ClientContext&, const Event&);
 using packet_handler = void(*)(ClientContext&, protocol::ClientOpcode);
 
 template<typename T>

--- a/src/realm/states/World.cpp
+++ b/src/realm/states/World.cpp
@@ -35,7 +35,7 @@ void handle_packet(ClientContext& ctx, protocol::ClientOpcode opcode) {
 	}
 }
 
-void handle_event(ClientContext& ctx, const Event* event) {
+void handle_event(ClientContext& ctx, const Event& event) {
 
 }
 

--- a/src/realm/states/World.h
+++ b/src/realm/states/World.h
@@ -15,7 +15,7 @@ namespace ember::realm::world {
 
 void enter(ClientContext& ctx);
 void handle_packet(ClientContext& ctx, protocol::ClientOpcode opcode);
-void handle_event(ClientContext& ctx, const Event* event);
+void handle_event(ClientContext& ctx, const Event& event);
 void exit(ClientContext& ctx);
 
 } // world, realm, ember

--- a/src/realm/states/WorldEnter.cpp
+++ b/src/realm/states/WorldEnter.cpp
@@ -46,9 +46,9 @@ std::uint32_t get_time() {
 	return tm_now.tm_min + hour + dow + day + month + year;
 }
 
-void initiate_player_login(ClientContext& ctx, const PlayerLogin* event) {
+void initiate_player_login(ClientContext& ctx, const PlayerLogin& event) {
     auto& state_ctx = std::get<Context>(ctx.state_ctx);
-    state_ctx.character_id = event->character_id_;
+    state_ctx.character_id = event.character_id_;
 
 	protocol::smsg_trigger_cinematic cinematic;
 	cinematic->id = 81;
@@ -517,37 +517,37 @@ void system_notification(ClientContext& ctx, std::string_view message) {
 	ctx.handler.send(packet);
 }
 
-void log_msg(ClientContext& ctx, const LogRedirect* event) {
-	if(event->type == LogRedirect::Type::console) {
-		system_notification(ctx, event->message);
+void log_msg(ClientContext& ctx, const LogRedirect& event) {
+	if(event.type == LogRedirect::Type::console) {
+		system_notification(ctx, event.message);
 		return;
 	}
 
 	protocol::smsg_messagechat msg;
 	msg->language = 0;
 	msg->type = protocol::server::SYSTEM;
-	msg->message = event->message;
+	msg->message = event.message;
 	msg->player_guid = 0;
 	msg->player_tag = protocol::server::TAG_NONE;
 	ctx.handler.send(msg);
 }
 
-void system_msg(ClientContext& ctx, const SystemMessage* event) {
-	if(event->type == SystemMessage::Type::console) {
-		system_notification(ctx, event->message);
+void system_msg(ClientContext& ctx, const SystemMessage& event) {
+	if(event.type == SystemMessage::Type::console) {
+		system_notification(ctx, event.message);
 		return;
 	}
 
 	protocol::smsg_messagechat msg;
 	msg->language = 0;
 
-	if(event->type == SystemMessage::Type::whisper) {
+	if(event.type == SystemMessage::Type::whisper) {
 		msg->type = protocol::server::MONSTER_WHISPER;
 		msg->monster_name = "System";
-		msg->message = event->message;
+		msg->message = event.message;
 	} else {
 		msg->type = protocol::server::SYSTEM;
-		msg->message = std::format("[System] {}", event->message);
+		msg->message = std::format("[System] {}", event.message);
 	}
 
 	msg->player_guid = 0;
@@ -555,18 +555,18 @@ void system_msg(ClientContext& ctx, const SystemMessage* event) {
 	ctx.handler.send(msg);
 }
 
-void handle_event(ClientContext& ctx, const Event* event) {
+void handle_event(ClientContext& ctx, const Event& event) {
 	using enum EventType;
 
-    switch(event->type) {
+    switch(event.type) {
         case player_login:
-            initiate_player_login(ctx, static_cast<const PlayerLogin*>(event));
+            initiate_player_login(ctx, static_cast<const PlayerLogin&>(event));
             break;
 		case system_message:
-			system_msg(ctx, static_cast<const SystemMessage*>(event));
+			system_msg(ctx, static_cast<const SystemMessage&>(event));
 			break;
 		case log_redirect:
-			log_msg(ctx, static_cast<const LogRedirect*>(event));
+			log_msg(ctx, static_cast<const LogRedirect&>(event));
 			break;
         default:
             break;

--- a/src/realm/states/WorldEnter.h
+++ b/src/realm/states/WorldEnter.h
@@ -15,7 +15,7 @@ namespace ember::realm::world_enter {
 
 void enter(ClientContext& ctx);
 void handle_packet(ClientContext& ctx, protocol::ClientOpcode opcode);
-void handle_event(ClientContext& ctx, const Event* event);
+void handle_event(ClientContext& ctx, const Event& event);
 void exit(ClientContext& ctx);
 
 } // world_enter, realm, ember

--- a/src/realm/states/WorldTransfer.h
+++ b/src/realm/states/WorldTransfer.h
@@ -22,7 +22,7 @@ void handle_packet(ClientContext& ctx, protocol::ClientOpcode opcode) {
 	assert(false && "Unused state");
 }
 
-void handle_event(ClientContext& ctx, const Event* event) {
+void handle_event(ClientContext& ctx, const Event& event) {
 	assert(false && "Unused state");
 }
 


### PR DESCRIPTION
- Events should always be taken by reference
- Remove the unique_ptr overload - ownership semantics over event data should be encoded within the event (e.g. shared_ptr member in an event) rather than by event ownership