### PR TITLE
Tidy up client creation

### DIFF
--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -11,7 +11,7 @@ set(LIBRARY_HDR
     Config.h
     Event.h
     EventDispatcher.h
-	EventDispatcher.inl
+    EventDispatcher.inl
     Events.h
     EventTypes.h
     SessionManager.h
@@ -63,6 +63,8 @@ set(LIBRARY_HDR
     ServiceContextImpl.h
     ConfigStore.h
     ClientBuilder.h
+    ClientHandlerBuilder.h
+    ClientConnectionBuilder.h
     Client.h
     BroadcastTimer.h
     Forwards.h

--- a/src/realm/Client.h
+++ b/src/realm/Client.h
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include "ClientConnection.h"
-#include "ClientHandler.h"
+#include "ClientConnectionBuilder.h"
+#include "ClientHandlerBuilder.h"
 #include "Forwards.h"
 #include "SocketType.h"
 #include <logger/Logger.h>
@@ -27,10 +27,9 @@ private:
 	ClientConnection connection_;
 
 public:
-	Client(tcp_socket socket, std::size_t index, const ConfigStore& store, EventDispatcher& dispatcher,
-		   RealmQueue& queue, AccountClient& account_rpc, CharacterClient& character_rpc, log::Logger& logger)
-		: handler_(index, socket.get_executor(), store, dispatcher, queue, account_rpc, character_rpc, logger)
-		, connection_(std::move(socket), logger) {
+	Client(ClientHandlerBuilder ch_builder, ClientConnectionBuilder cc_builder, tcp_socket socket, std::size_t index)
+		: handler_(ch_builder.create(index, socket.get_executor()))
+		, connection_(cc_builder.create(std::move(socket))) {
 		handler_.set_connection(&connection_);
 		connection_.set_handler(&handler_);
 	}

--- a/src/realm/ClientBuilder.h
+++ b/src/realm/ClientBuilder.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "ClientHandlerBuilder.h"
+#include "ClientConnectionBuilder.h"
 #include "Forwards.h"
 #include "unique_client_ptr.h"
 #include <memory>
@@ -17,37 +19,23 @@ namespace ember::realm {
 class ClientBuilder {
 	constexpr static auto allocator_tag = "client_allocator";
 
-	ClientAllocator allocator_;
-	const ConfigStore& store_;
-	EventDispatcher& dispatcher_;
-	RealmQueue& queue_;
-	AccountClient& account_rpc_;
-	CharacterClient& character_rpc_;
-	log::Logger& logger_;
+	mutable ClientAllocator allocator_;
+	ClientHandlerBuilder ch_builder_;
+	ClientConnectionBuilder cc_builder_;
 
-	unique_client_ptr make_unique_client(tcp_socket socket, std::size_t index) {
+	unique_client_ptr make_unique_client(tcp_socket socket, std::size_t index) const {
 		return unique_client_ptr(allocator_.allocate(
-			std::move(socket), index, store_, dispatcher_, queue_,
-			account_rpc_, character_rpc_, logger_
+			ch_builder_, cc_builder_, std::move(socket), index
 		), ClientDeleter(&allocator_));
 	}
 
 public:
-	ClientBuilder(const ConfigStore& store,
-	              EventDispatcher& dispatcher,
-	              RealmQueue& queue,
-	              AccountClient& account_rpc,
-	              CharacterClient& character_rpc,
-	              log::Logger& logger)
+	ClientBuilder(ClientHandlerBuilder ch_builder, ClientConnectionBuilder cc_builder)
 		: allocator_(allocator_tag)
-		, store_(store)
-		, dispatcher_(dispatcher)
-		, queue_(queue)
-		, account_rpc_(account_rpc)
-		, character_rpc_(character_rpc)
-		, logger_(logger) {}
+		, ch_builder_(ch_builder)
+		, cc_builder_(cc_builder) {}
 
-	unique_client_ptr create(tcp_socket socket, std::size_t index) {
+	unique_client_ptr create(tcp_socket socket, std::size_t index) const {
 		return make_unique_client(std::move(socket), index);
 	}
 };

--- a/src/realm/ClientConnectionBuilder.h
+++ b/src/realm/ClientConnectionBuilder.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Ember
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include "ClientConnection.h"
+
+namespace ember::realm {
+
+class ClientConnectionBuilder {
+	log::Logger& logger_;
+
+public:
+	ClientConnectionBuilder(log::Logger& logger)
+		: logger_(logger) {}
+
+	ClientConnection create(tcp_socket socket) const {
+		return ClientConnection(std::move(socket), logger_);
+	}
+};
+
+} // realm, ember

--- a/src/realm/ClientHandlerBuilder.h
+++ b/src/realm/ClientHandlerBuilder.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Ember
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include "ClientHandler.h"
+
+namespace ember::realm {
+
+class ClientHandlerBuilder {
+	const ConfigStore& store_;
+	EventDispatcher& dispatcher_;
+	RealmQueue& queue_;
+	AccountClient& account_rpc_;
+	CharacterClient& character_rpc_;
+	log::Logger& logger_;
+
+public:
+	ClientHandlerBuilder(const ConfigStore& store, EventDispatcher& dispatcher,
+	                     RealmQueue& queue, AccountClient& account_rpc,
+	                     CharacterClient& character_rpc, log::Logger& logger)
+		: store_(store)
+		, dispatcher_(dispatcher)
+		, queue_(queue)
+		, account_rpc_(account_rpc)
+		, character_rpc_(character_rpc)
+		, logger_(logger) {}
+
+	ClientHandler create(std::size_t index, executor executor) const {
+		return ClientHandler(
+			index, executor, store_, dispatcher_, queue_, account_rpc_, character_rpc_, logger_
+		);
+	}
+};
+
+} // realm, ember

--- a/src/realm/Service.cpp
+++ b/src/realm/Service.cpp
@@ -238,9 +238,13 @@ void Service::initialise(const opts::variables_map& args) try {
 	const auto max_socks = utility::max_sockets_desc();
 	SLOG_INFO(logger, "Max allowed sockets: {}", max_socks);
 
-	ClientBuilder builder(
+	ClientConnectionBuilder cc_builder(logger);
+
+	ClientHandlerBuilder ch_builder(
 		*ctx->config_store, *ctx->dispatcher, *ctx->queue, *ctx->rpc_account, *ctx->rpc_character, logger
 	);
+
+	ClientBuilder builder(ch_builder, cc_builder);
 
 	// Start network listener
 	SLOG_INFO(logger, "Starting network service on {}:{}...", interface, port);


### PR DESCRIPTION
Feels a little backwards to be passing builders to the client object but it's the best solution I can come up with that doesn't involve making the objects movable (opens up multiple cans of worms) or allocating them (more indirections, worse locality for message handling). Could tidy it up further by binding the additional arguments to the create functions and passing those to the client builder but that'd introduce its own overhead and is probably over the top.