### PR TITLE
Implement SizedString to emulate string_views between ABI boundaries

### DIFF
--- a/sdk/blaze/include/ember/blaze/Blaze.h
+++ b/sdk/blaze/include/ember/blaze/Blaze.h
@@ -18,8 +18,17 @@ extern "C" {
 EMBER_EXPORT SDKBuildMeta sdk_build();
 EMBER_EXPORT uint8_t sdk_initialise(BlazeHostAPI api, PluginID pid);
 
-void blaze_log(const char* message, uint32_t size, uint8_t log_level);
-void blaze_slog(const char* message, uint32_t size, uint8_t log_level);
+void blaze_log(const char* message, uint8_t log_level);
+void blaze_slog(const char* message, uint8_t log_level);
+void blaze_log_sstr(const SizedString name, uint8_t log_level);
+void blaze_slog_sstr(const SizedString name, uint8_t log_level);
+
+void blaze_command_create(const char* name, const char* description);
+void blaze_command_create_sstr(const SizedString name, const SizedString description);
+bool blaze_command_destroy(void* command);
+bool blaze_command_add_argument(void* command, const char* name, uint8_t type, bool required);
+bool blaze_command_add_argument_sstr(void* command, const SizedString name, uint8_t type, bool required);
+bool blaze_command_callback(void* command);
 
 PluginID blaze_get_plugin_id();
 

--- a/sdk/blaze/include/ember/blaze/Blaze.hpp
+++ b/sdk/blaze/include/ember/blaze/Blaze.hpp
@@ -59,11 +59,11 @@ enum class ArgumentType : std::uint8_t {
 };
 
 inline void log(std::string_view message, LogLevel log_level) {
-	blaze_log(message.data(), message.size(), std::to_underlying(log_level));
+	blaze_log_sstr({ message.data(), message.size() }, std::to_underlying(log_level));
 }
 
 inline void slog(std::string_view message, LogLevel log_level) {
-	blaze_slog(message.data(), message.size(), std::to_underlying(log_level));
+	blaze_slog_sstr({ message.data(), message.size() }, std::to_underlying(log_level));
 }
 
 inline PluginID plugin_id() {

--- a/sdk/blaze/src/Blaze.cpp
+++ b/sdk/blaze/src/Blaze.cpp
@@ -43,7 +43,7 @@ uint8_t sdk_initialise(const BlazeHostAPI api, const PluginID pid) {
 SizedString cstring_to_sstr(const char* string) {
 	return {
 		.data = string,
-		.size = std::strlen(string)
+		.size = static_cast<uint64_t>(std::strlen(string))
 	};
 }
 

--- a/sdk/blaze/src/Blaze.cpp
+++ b/sdk/blaze/src/Blaze.cpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <ember/blaze/Blaze.h>
+#include <cstring>
 
 static BlazeHostAPI host_api;
 static PluginID plugin_id;
@@ -38,14 +39,61 @@ uint8_t sdk_initialise(const BlazeHostAPI api, const PluginID pid) {
 	return SDK_INIT_OK;
 }
 
+// todo, move
+SizedString cstring_to_sstr(const char* string) {
+	return {
+		.data = string,
+		.size = std::strlen(string)
+	};
+}
+
 PluginID blaze_get_plugin_id() {
 	return plugin_id;
 }
 
-void blaze_log(const char* message, const uint32_t size, uint8_t log_level) {
-	(*host_api.log_async)(message, size, log_level, blaze_get_plugin_id());
+void blaze_log(const char* message, const uint8_t log_level) {
+	const auto sstr = cstring_to_sstr(message);
+	(*host_api.log_async)(&sstr, log_level, blaze_get_plugin_id());
 }
 
-void blaze_slog(const char* message, const uint32_t size, uint8_t log_level) {
-	(*host_api.log_sync)(message, size, log_level, blaze_get_plugin_id());
+void blaze_slog(const char* message, const uint8_t log_level) {
+	const auto sstr = cstring_to_sstr(message);
+	(*host_api.log_sync)(&sstr, log_level, blaze_get_plugin_id());
+}
+
+void blaze_log_sstr(const SizedString message, const uint8_t log_level) {
+	(*host_api.log_async)(&message, log_level, blaze_get_plugin_id());
+}
+
+void blaze_slog_sstr(const SizedString message, const uint8_t log_level) {
+	(*host_api.log_sync)(&message, log_level, blaze_get_plugin_id());
+}
+
+void blaze_command_create(const char* name, const char* description) {
+	const auto name_sstr = cstring_to_sstr(name);
+	const auto desc_sstr = cstring_to_sstr(description);
+	(*host_api.command_create)(&name_sstr, &desc_sstr);
+}
+
+void blaze_command_create_sstr(const SizedString name, const SizedString description) {
+	(*host_api.command_create)(&name, &description);
+}
+
+bool blaze_command_destroy(void* command) {
+	(*host_api.command_destroy)(command);
+}
+
+bool blaze_command_add_argument(void* command, const char* name,
+                                const uint8_t type, const bool required) {
+	const auto sstr = cstring_to_sstr(name);
+	(*host_api.command_add_argument)(command, &sstr, type, required);
+}
+
+bool blaze_command_add_argument_sstr(void* command, const SizedString name,
+                                const uint8_t type, const bool required) {
+	(*host_api.command_add_argument)(command, &name, type, required);
+}
+
+bool blaze_command_callback(void* command) {
+	(*host_api.command_callback)(command);
 }

--- a/src/tools/blaze/Common.h
+++ b/src/tools/blaze/Common.h
@@ -56,7 +56,7 @@ typedef uint64_t PluginID;
 
 typedef struct {
 	const char* data;
-	uint32_t size;
+	uint64_t size;
 } SizedString;
 
 // plugin API

--- a/src/tools/blaze/Common.h
+++ b/src/tools/blaze/Common.h
@@ -54,18 +54,23 @@ typedef uint64_t PluginID;
 #define CAT_UINT_32 9
 #define CAT_UINT_64 10
 
+typedef struct {
+	const char* data;
+	uint32_t size;
+} SizedString;
+
 // plugin API
 typedef void(*plugin_load_fn)();
 typedef void(*plugin_unload_fn)();
 
 // logging API
-typedef void(*log_async_fn)(const char* message, uint32_t size, uint8_t level, PluginID pid);
-typedef void(*log_sync_fn)(const char* message, uint32_t size, uint8_t level, PluginID pid);
+typedef void(*log_async_fn)(const SizedString* message, uint8_t level, PluginID pid);
+typedef void(*log_sync_fn)(const SizedString* message, uint8_t level, PluginID pid);
 
 // command API - todo, opaque struct once I've cleaned the other files up
-typedef void*(*command_create_fn)(const char* name, const char* description);
+typedef void*(*command_create_fn)(const SizedString* name, const SizedString* description);
 typedef bool(*command_destroy_fn)(void* command);
-typedef bool(*command_add_argument_fn)(void* command, const char* name, uint8_t type, bool required);
+typedef bool(*command_add_argument_fn)(void* command, const SizedString* name, uint8_t type, bool required);
 typedef bool(*command_callback_fn)(void* command);
 
 typedef struct {

--- a/src/tools/blaze/api/Commands.cpp
+++ b/src/tools/blaze/api/Commands.cpp
@@ -23,40 +23,40 @@ Command command_create(const SizedString* name, const SizedString* description) 
 }
 
 template<typename T>
-bool command_arg_register(commands::Command& command, const std::string& name, std::uint8_t type) {
+bool command_arg_register(commands::Command& command, std::string name, std::uint8_t type) {
 	switch(type) {
 		case cat_string:
-			command.argument<std::string>(name, T{});
+			command.argument<std::string>(std::move(name), T{});
 			break;
 		case cat_float:
-			command.argument<float>(name, T{});
+			command.argument<float>(std::move(name), T{});
 			break;
 		case cat_double:
-			command.argument<double>(name, T{});
+			command.argument<double>(std::move(name), T{});
 			break;
 		case cat_int_8:
-			command.argument<std::int8_t>(name, T{});
+			command.argument<std::int8_t>(std::move(name), T{});
 			break;
 		case cat_int_16:
-			command.argument<std::int16_t>(name, T{});
+			command.argument<std::int16_t>(std::move(name), T{});
 			break;
 		case cat_int_32:
-			command.argument<std::int32_t>(name, T{});
+			command.argument<std::int32_t>(std::move(name), T{});
 			break;
 		case cat_int_64:
-			command.argument<std::int64_t>(name, T{});
+			command.argument<std::int64_t>(std::move(name), T{});
 			break;
 		case cat_uint_8:
-			command.argument<std::uint8_t>(name, T{});
+			command.argument<std::uint8_t>(std::move(name), T{});
 			break;
 		case cat_uint_16:
-			command.argument<std::uint16_t>(name, T{});
+			command.argument<std::uint16_t>(std::move(name), T{});
 			break;
 		case cat_uint_32:
-			command.argument<std::uint32_t>(name, T{});
+			command.argument<std::uint32_t>(std::move(name), T{});
 			break;
 		case cat_uint_64:
-			command.argument<std::uint64_t>(name, T{});
+			command.argument<std::uint64_t>(std::move(name), T{});
 			break;
 		default:
 			return false;

--- a/src/tools/blaze/api/Commands.cpp
+++ b/src/tools/blaze/api/Commands.cpp
@@ -13,8 +13,8 @@ namespace ember::blaze {
 
 Command command_create(const SizedString* name, const SizedString* description) {
 	auto registry = InterfaceContainer::get_instance().command_root();
-	auto command = registry->create({ name->data, name->size });
-	command->description({ description->data, description->size });
+	auto command = registry->create(std::string(name->data, name->size));
+	command->description(std::string(description->data, description->size));
 	InterfaceContainer::get_instance().plugin_command_registry()->insert("test", command);
 
 	return {

--- a/src/tools/blaze/api/Commands.cpp
+++ b/src/tools/blaze/api/Commands.cpp
@@ -73,12 +73,12 @@ bool command_add_argument(Command command, const SizedString* name, std::uint8_t
 		return false;
 	}
 
-	std::string view(name->data, name->size);
+	std::string name_str(name->data, name->size);
 
 	if(required) {
-		return command_arg_register<commands::required_t>(*result, std::move(view), type);
+		return command_arg_register<commands::required_t>(*result, std::move(name_str), type);
 	} else {
-		return command_arg_register<commands::optional_t>(*result, std::move(view), type);
+		return command_arg_register<commands::optional_t>(*result, std::move(name_str), type);
 	}
 }
 

--- a/src/tools/blaze/api/Commands.cpp
+++ b/src/tools/blaze/api/Commands.cpp
@@ -11,10 +11,10 @@
 
 namespace ember::blaze {
 
-Command command_create(const char* name, const char* description) {
+Command command_create(const SizedString* name, const SizedString* description) {
 	auto registry = InterfaceContainer::get_instance().command_root();
-	auto command = registry->create(name);
-	command->description(description);
+	auto command = registry->create({ name->data, name->size });
+	command->description({ description->data, description->size });
 	InterfaceContainer::get_instance().plugin_command_registry()->insert("test", command);
 
 	return {
@@ -23,7 +23,7 @@ Command command_create(const char* name, const char* description) {
 }
 
 template<typename T>
-bool command_arg_register(commands::Command& command, const char* name, std::uint8_t type) {
+bool command_arg_register(commands::Command& command, const std::string& name, std::uint8_t type) {
 	switch(type) {
 		case cat_string:
 			command.argument<std::string>(name, T{});
@@ -65,7 +65,7 @@ bool command_arg_register(commands::Command& command, const char* name, std::uin
 	return true;
 }
 
-bool command_add_argument(Command command, const char* name, std::uint8_t type, bool required) {
+bool command_add_argument(Command command, const SizedString* name, std::uint8_t type, bool required) {
 	auto pcr = InterfaceContainer::get_instance().plugin_command_registry();
 	auto result = pcr->lookup(command.impl);
 
@@ -73,10 +73,12 @@ bool command_add_argument(Command command, const char* name, std::uint8_t type, 
 		return false;
 	}
 
+	std::string view(name->data, name->size);
+
 	if(required) {
-		return command_arg_register<commands::required_t>(*result, name, type);
+		return command_arg_register<commands::required_t>(*result, std::move(view), type);
 	} else {
-		return command_arg_register<commands::optional_t>(*result, name, type);
+		return command_arg_register<commands::optional_t>(*result, std::move(view), type);
 	}
 }
 

--- a/src/tools/blaze/api/Commands.h
+++ b/src/tools/blaze/api/Commands.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Visibility.h"
+#include "../Common.h"
 #include <commands/Commands.h>
 #include <cstdint>
 
@@ -34,9 +35,9 @@ enum CommandArgType {
 	cat_uint_64,
 };
 
-EMBER_EXPORT Command command_create(const char* name, const char* description);
+EMBER_EXPORT Command command_create(const SizedString* name, const SizedString* description);
 EMBER_EXPORT bool command_destroy(Command command);
-EMBER_EXPORT bool command_add_argument(Command command, const char* name, std::uint8_t type, bool required);
+EMBER_EXPORT bool command_add_argument(Command command, const SizedString* name, std::uint8_t type, bool required);
 EMBER_EXPORT bool command_callback(Command command);
 
 } // extern "C"

--- a/src/tools/blaze/api/Logging.cpp
+++ b/src/tools/blaze/api/Logging.cpp
@@ -10,8 +10,8 @@
 #include "Logging.h"
 #include <logger/Logger.h>
 
-void log_async(const char* message, const std::uint32_t size, std::uint8_t level, PluginID pid) {
-	std::string_view view(message, size);
+void log_async(const SizedString* message, std::uint8_t level, PluginID pid) {
+	std::string_view view(message->data, message->size);
 	const auto fmt = std::format("[{}] {}", pid, view);
 
 	auto logger = ember::log::global_logger(); // todo, temp!
@@ -40,8 +40,8 @@ void log_async(const char* message, const std::uint32_t size, std::uint8_t level
 	}
 }
 
-void log_sync(const char* message, const std::uint32_t size, std::uint8_t level, PluginID pid) {
-	std::string_view view(message, size);
+void log_sync(const SizedString* message, std::uint8_t level, PluginID pid) {
+	std::string_view view(message->data, message->size);
 	const auto fmt = std::format("[{}] {}", pid, view);
 
 	auto logger = ember::log::global_logger(); // todo, temp!

--- a/src/tools/blaze/api/Logging.h
+++ b/src/tools/blaze/api/Logging.h
@@ -14,7 +14,7 @@
 
 extern "C" {
 
-EMBER_EXPORT void log_async(const char* message, std::uint32_t size, std::uint8_t level, PluginID pid);
-EMBER_EXPORT void log_sync(const char* message, std::uint32_t size, std::uint8_t level, PluginID pid);
+EMBER_EXPORT void log_async(const SizedString* message, std::uint8_t level, PluginID pid);
+EMBER_EXPORT void log_sync(const SizedString* message, std::uint8_t level, PluginID pid);
 
 } // extern "C"


### PR DESCRIPTION
Using _sstr suffixes for now to keep the pure C API clean for users with the C++ wrapper calling _sstr variants to convert from string_view/strings to SizedString which can be converted back on the other side